### PR TITLE
Add `normalize` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,25 @@ Validates whether an input is valid JSON schema.
 
 ## Installation
 
-```
+```nohighlight
 go install github.com/giantswarm/schemalint@latest
 ```
 
 ## Usage
 
+### Validation
+
+Verify whether a file is valid JSON Schema.
+
 ```nohighlight
-$ schemalint path/to/myschema.json
-path/to/myschema.json: PASS
+$ schemalint verify myschema.json
+myschema.json: PASS
+```
+
+### Normalization
+
+Create a normalized (white space, sorting) representation of a JSON Schema file.
+
+```nohighlight
+$ schemalint normalize myschema.json > normalized.json
 ```

--- a/cmd/normalize.go
+++ b/cmd/normalize.go
@@ -18,7 +18,7 @@ var (
 		Long: `Normalize the given JSON schema input.
 
 The normalized JSON will be printed to STDOUT.`,
-		Example:      "  schemalint path/to/schema.json > normalized.json",
+		Example:      `  schemalint path/to/schema.json > normalized.json`,
 		Args:         cobra.MinimumNArgs(1),
 		ArgAliases:   []string{"PATH"},
 		Run:          normalizeRun,
@@ -35,7 +35,7 @@ func normalizeRun(cmd *cobra.Command, args []string) {
 
 	output, err := normalize.Normalize(input)
 	if err != nil {
-		log.Fatalf("Error reading file %s: %s", path, err)
+		log.Fatalf("Error processing file %s.\nProbably this is not valid JSON.\nDetails: %s", path, err)
 	}
 
 	fmt.Println(string(output))

--- a/cmd/normalize.go
+++ b/cmd/normalize.go
@@ -12,8 +12,13 @@ import (
 
 var (
 	normalizeCmd = &cobra.Command{
-		Use:          "normalize PATH",
-		Short:        "Normalize the given JSON schema input",
+		Use:     "normalize PATH",
+		Short:   "Normalize the given JSON schema input",
+		Aliases: []string{"normalise", "norm"},
+		Long: `Normalize the given JSON schema input.
+
+The normalized JSON will be printed to STDOUT.`,
+		Example:      "  schemalint path/to/schema.json > normalized.json",
 		Args:         cobra.MinimumNArgs(1),
 		ArgAliases:   []string{"PATH"},
 		Run:          normalizeRun,

--- a/cmd/normalize.go
+++ b/cmd/normalize.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/schemalint/pkg/normalize"
+)
+
+var (
+	normalizeCmd = &cobra.Command{
+		Use:          "normalize PATH",
+		Short:        "Normalize the given JSON schema input",
+		Args:         cobra.MinimumNArgs(1),
+		ArgAliases:   []string{"PATH"},
+		Run:          normalizeRun,
+		SilenceUsage: true,
+	}
+)
+
+func normalizeRun(cmd *cobra.Command, args []string) {
+	path := args[0]
+	input, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatalf("Error reading file %s: %s", path, err)
+	}
+
+	output, err := normalize.Normalize(input)
+	if err != nil {
+		log.Fatalf("Error reading file %s: %s", path, err)
+	}
+
+	fmt.Println(string(output))
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,40 +1,25 @@
 package cmd
 
 import (
-	"log"
-
 	"github.com/spf13/cobra"
-
-	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 var (
 	rootCmd = &cobra.Command{
-		Use:          "schemalint PATH",
-		Short:        "Validate whether a file is valid JSON schema",
+		Use:          "schemalint",
+		Short:        "Validate and normalize JSON schema",
 		Args:         cobra.MinimumNArgs(1),
 		ArgAliases:   []string{"PATH"},
-		Run:          validate,
 		SilenceUsage: true,
 	}
 )
 
+func init() {
+	rootCmd.AddCommand(normalizeCmd)
+	rootCmd.AddCommand(verifyCmd)
+}
+
 // Execute executes the root command.
 func Execute() error {
 	return rootCmd.Execute()
-}
-
-// Main validation command
-func validate(cmd *cobra.Command, args []string) {
-	url, err := lint.ToFileURL(args[0])
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	err = lint.CompileAuto(url)
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	log.Printf("%s: PASS", args[0])
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"log"
-	"os"
-	"reflect"
 
 	"github.com/spf13/cobra"
 
@@ -35,7 +33,6 @@ func verifyRun(cmd *cobra.Command, args []string) {
 			log.Fatal(err)
 		}
 	}
-
 
 	log.Printf("%s: PASS", args[0])
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"log"
+	"os"
+	"reflect"
+
+	"github.com/spf13/cobra"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+var (
+	verifyCmd = &cobra.Command{
+		Use:          "verify PATH",
+		Short:        "Verify the given JSON schema input",
+		Args:         cobra.MinimumNArgs(1),
+		ArgAliases:   []string{"PATH"},
+		Run:          verifyRun,
+		SilenceUsage: true,
+	}
+)
+
+func verifyRun(cmd *cobra.Command, args []string) {
+	path := args[0]
+
+	// Verify JSON schema validity (lint)
+	{
+		url, err := lint.ToFileURL(path)
+		if err != nil {
+			log.Fatal(err)
+		}
+		err = lint.CompileAuto(url)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+
+	log.Printf("%s: PASS", args[0])
+}

--- a/pkg/normalize/normalize.go
+++ b/pkg/normalize/normalize.go
@@ -1,0 +1,32 @@
+// Package normalize providesa a function to process a JSON input and return it in
+// normalized form.
+package normalize
+
+import "encoding/json"
+
+const (
+	// Four spaces indentation.
+	indendation = "    "
+	prefix      = ""
+)
+
+// Normalize takes JSON and returns normalized JSON.
+func Normalize(jsonBytes []byte) ([]byte, error) {
+	var data interface{}
+	err := json.Unmarshal(jsonBytes, &data)
+	if err != nil {
+		return nil, err
+	}
+
+	// We use the fact that MarshalIndent applies a specific sorting
+	// of object keys, apart from normalizing indentation.
+	output, err := json.MarshalIndent(data, prefix, indendation)
+	if err != nil {
+		return nil, err
+	}
+
+	// trailing newline
+	output = append(output, []byte("\n")...)
+
+	return output, nil
+}

--- a/pkg/normalize/normalize_test.go
+++ b/pkg/normalize/normalize_test.go
@@ -1,0 +1,103 @@
+// Package normalize providesa a function to process a JSON input and return it in
+// normalized form.
+package normalize
+
+import (
+	"flag"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+)
+
+var (
+	update = flag.Bool("update", false, "update the golden files of this test")
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}
+
+func TestNormalize(t *testing.T) {
+	tests := []struct {
+		name       string
+		inputPath  string
+		goldenPath string
+		wantErr    bool
+	}{
+		{
+			name:       "First",
+			inputPath:  "1.json",
+			goldenPath: "1.golden",
+			wantErr:    false,
+		},
+		{
+			name:       "Second",
+			inputPath:  "2.json",
+			goldenPath: "2.golden",
+			wantErr:    false,
+		},
+		{
+			name:       "Third",
+			inputPath:  "3.json",
+			goldenPath: "3.golden",
+			wantErr:    false,
+		},
+		{
+			name:       "Fourth, with actual schema",
+			inputPath:  "4.json",
+			goldenPath: "4.golden",
+			wantErr:    false,
+		},
+		{
+			name:       "Fifth, trailing newline missing",
+			inputPath:  "5.json",
+			goldenPath: "5.golden",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input, err := os.ReadFile("testdata/" + tt.inputPath)
+			if err != nil {
+				t.Fatalf("Normalize() error when reading file: %v", err)
+			}
+
+			got, err := Normalize(input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Normalize() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			want := goldenValue(t, "testdata/"+tt.goldenPath, got, *update)
+
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("Normalize() = %v, want %v", string(got), string(want))
+			}
+		})
+	}
+}
+
+func goldenValue(t *testing.T, goldenPath string, actual []byte, update bool) []byte {
+	t.Helper()
+
+	f, err := os.OpenFile(goldenPath, os.O_RDWR, 0644)
+	defer f.Close()
+
+	if update {
+		_, err := f.Write(actual)
+		if err != nil {
+			t.Fatalf("Error writing to file %s: %s", goldenPath, err)
+		}
+
+		return actual
+	}
+
+	content, err := io.ReadAll(f)
+	if err != nil {
+		t.Fatalf("Error opening file %s: %s", goldenPath, err)
+	}
+	return content
+}

--- a/pkg/normalize/normalize_test.go
+++ b/pkg/normalize/normalize_test.go
@@ -84,6 +84,9 @@ func goldenValue(t *testing.T, goldenPath string, actual []byte, update bool) []
 	t.Helper()
 
 	f, err := os.OpenFile(goldenPath, os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatalf("Error opening to file %s: %s", goldenPath, err)
+	}
 	defer f.Close()
 
 	if update {

--- a/pkg/normalize/normalize_test.go
+++ b/pkg/normalize/normalize_test.go
@@ -56,6 +56,11 @@ func TestNormalize(t *testing.T) {
 			goldenPath: "5.golden",
 			wantErr:    false,
 		},
+		{
+			name:      "Sixth, not JSON",
+			inputPath: "6.txt",
+			wantErr:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -66,15 +71,25 @@ func TestNormalize(t *testing.T) {
 			}
 
 			got, err := Normalize(input)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Normalize() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			var want []byte
 
-			want := goldenValue(t, "testdata/"+tt.goldenPath, got, *update)
+			if !tt.wantErr {
+				if err != nil {
+					t.Errorf("Normalize() unexpected error = %v", err)
+					return
+				}
 
-			if !reflect.DeepEqual(got, want) {
-				t.Errorf("Normalize() = %v, want %v", string(got), string(want))
+				if tt.goldenPath != "" {
+					want = goldenValue(t, "testdata/"+tt.goldenPath, got, *update)
+					if !reflect.DeepEqual(got, want) {
+						t.Errorf("Normalize() = %v, want %v", string(got), string(want))
+					}
+				}
+			} else {
+				// Error expected
+				if err == nil {
+					t.Error("Normalize() expected error, got nil")
+				}
 			}
 		})
 	}

--- a/pkg/normalize/normalize_test.go
+++ b/pkg/normalize/normalize_test.go
@@ -61,6 +61,13 @@ func TestNormalize(t *testing.T) {
 			inputPath: "6.txt",
 			wantErr:   true,
 		},
+		// Property is defined multiple times. Last value wins.
+		{
+			name:       "Seventh, duplicate key",
+			inputPath:  "7.json",
+			goldenPath: "7.golden",
+			wantErr:    false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/normalize/testdata/1.golden
+++ b/pkg/normalize/testdata/1.golden
@@ -1,0 +1,15 @@
+{
+    "$id": null,
+    "$schema": "",
+    "1": "number one",
+    "2": [
+        "two",
+        2,
+        "number",
+        1,
+        null
+    ],
+    "a": null,
+    "b": 123,
+    "c": {}
+}

--- a/pkg/normalize/testdata/1.json
+++ b/pkg/normalize/testdata/1.json
@@ -1,0 +1,9 @@
+{
+"c":{},
+"1": "number one",
+"b": 123,
+"2": ["two", 2, "number", 1, null],
+"a": null,
+"$schema": "",
+"$id": null
+}

--- a/pkg/normalize/testdata/2.golden
+++ b/pkg/normalize/testdata/2.golden
@@ -1,0 +1,15 @@
+{
+    "$id": null,
+    "$schema": "",
+    "1": "number one",
+    "2": [
+        "two",
+        2,
+        "number",
+        1,
+        null
+    ],
+    "a": null,
+    "b": 123,
+    "c": {}
+}

--- a/pkg/normalize/testdata/2.json
+++ b/pkg/normalize/testdata/2.json
@@ -1,0 +1,1 @@
+{"c":{},"1":"number one","b":123,"2":["two",2,"number",1,null],"a":null,"$schema":"","$id":null}

--- a/pkg/normalize/testdata/3.golden
+++ b/pkg/normalize/testdata/3.golden
@@ -1,0 +1,1078 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "additionalProperties": false,
+            "properties": {
+                "foo": {
+                    "$ref": "#"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "foo": false
+                },
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": {
+                    "foo": {
+                        "foo": false
+                    }
+                },
+                "description": "recursive match",
+                "valid": true
+            },
+            {
+                "data": {
+                    "bar": false
+                },
+                "description": "mismatch",
+                "valid": false
+            },
+            {
+                "data": {
+                    "foo": {
+                        "bar": false
+                    }
+                },
+                "description": "recursive mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "bar": {
+                    "$ref": "#/properties/foo"
+                },
+                "foo": {
+                    "type": "integer"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "bar": 3
+                },
+                "description": "match",
+                "valid": true
+            },
+            {
+                "data": {
+                    "bar": true
+                },
+                "description": "mismatch",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                {
+                    "type": "integer"
+                },
+                {
+                    "$ref": "#/prefixItems/0"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "data": [
+                    1,
+                    2
+                ],
+                "description": "match array",
+                "valid": true
+            },
+            {
+                "data": [
+                    1,
+                    "foo"
+                ],
+                "description": "mismatch array",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "$defs": {
+                "percent%field": {
+                    "type": "integer"
+                },
+                "slash/field": {
+                    "type": "integer"
+                },
+                "tilde~field": {
+                    "type": "integer"
+                }
+            },
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "percent": {
+                    "$ref": "#/$defs/percent%25field"
+                },
+                "slash": {
+                    "$ref": "#/$defs/slash~1field"
+                },
+                "tilde": {
+                    "$ref": "#/$defs/tilde~0field"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "slash": "aoeu"
+                },
+                "description": "slash invalid",
+                "valid": false
+            },
+            {
+                "data": {
+                    "tilde": "aoeu"
+                },
+                "description": "tilde invalid",
+                "valid": false
+            },
+            {
+                "data": {
+                    "percent": "aoeu"
+                },
+                "description": "percent invalid",
+                "valid": false
+            },
+            {
+                "data": {
+                    "slash": 123
+                },
+                "description": "slash valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "tilde": 123
+                },
+                "description": "tilde valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "percent": 123
+                },
+                "description": "percent valid",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "$defs": {
+                "a": {
+                    "type": "integer"
+                },
+                "b": {
+                    "$ref": "#/$defs/a"
+                },
+                "c": {
+                    "$ref": "#/$defs/b"
+                }
+            },
+            "$ref": "#/$defs/c",
+            "$schema": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "data": 5,
+                "description": "nested ref valid",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "nested ref invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref applies alongside sibling keywords",
+        "schema": {
+            "$defs": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "foo": []
+                },
+                "description": "ref valid, maxItems valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "foo": [
+                        1,
+                        2,
+                        3
+                    ]
+                },
+                "description": "ref valid, maxItems invalid",
+                "valid": false
+            },
+            {
+                "data": {
+                    "foo": "string"
+                },
+                "description": "ref invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {
+            "$ref": "https://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "data": {
+                    "minLength": 1
+                },
+                "description": "remote ref valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "minLength": -1
+                },
+                "description": "remote ref invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "$ref": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "$ref": "a"
+                },
+                "description": "property named $ref valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "$ref": 2
+                },
+                "description": "property named $ref invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref, containing an actual $ref",
+        "schema": {
+            "$defs": {
+                "is-string": {
+                    "type": "string"
+                }
+            },
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "$ref": {
+                    "$ref": "#/$defs/is-string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "$ref": "a"
+                },
+                "description": "property named $ref valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "$ref": 2
+                },
+                "description": "property named $ref invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema true",
+        "schema": {
+            "$defs": {
+                "bool": true
+            },
+            "$ref": "#/$defs/bool",
+            "$schema": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "data": "foo",
+                "description": "any value is valid",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema false",
+        "schema": {
+            "$defs": {
+                "bool": false
+            },
+            "$ref": "#/$defs/bool",
+            "$schema": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "data": "foo",
+                "description": "any value is invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Recursive references between schemas",
+        "schema": {
+            "$defs": {
+                "node": {
+                    "$id": "http://localhost:1234/draft2020-12/node",
+                    "description": "node",
+                    "properties": {
+                        "subtree": {
+                            "$ref": "tree"
+                        },
+                        "value": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "value"
+                    ],
+                    "type": "object"
+                }
+            },
+            "$id": "http://localhost:1234/draft2020-12/tree",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "description": "tree of nodes",
+            "properties": {
+                "meta": {
+                    "type": "string"
+                },
+                "nodes": {
+                    "items": {
+                        "$ref": "node"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "meta",
+                "nodes"
+            ],
+            "type": "object"
+        },
+        "tests": [
+            {
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {
+                                        "value": 1.1
+                                    },
+                                    {
+                                        "value": 1.2
+                                    }
+                                ]
+                            },
+                            "value": 1
+                        },
+                        {
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {
+                                        "value": 2.1
+                                    },
+                                    {
+                                        "value": 2.2
+                                    }
+                                ]
+                            },
+                            "value": 2
+                        }
+                    ]
+                },
+                "description": "valid tree",
+                "valid": true
+            },
+            {
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {
+                                        "value": "string is invalid"
+                                    },
+                                    {
+                                        "value": 1.2
+                                    }
+                                ]
+                            },
+                            "value": 1
+                        },
+                        {
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {
+                                        "value": 2.1
+                                    },
+                                    {
+                                        "value": 2.2
+                                    }
+                                ]
+                            },
+                            "value": 2
+                        }
+                    ]
+                },
+                "description": "invalid tree",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "refs with quote",
+        "schema": {
+            "$defs": {
+                "foo\"bar": {
+                    "type": "number"
+                }
+            },
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo\"bar": {
+                    "$ref": "#/$defs/foo%22bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "foo\"bar": 1
+                },
+                "description": "object with numbers is valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "foo\"bar": "1"
+                },
+                "description": "object with strings is invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref creates new scope when adjacent to keywords",
+        "schema": {
+            "$defs": {
+                "A": {
+                    "unevaluatedProperties": false
+                }
+            },
+            "$ref": "#/$defs/A",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "prop1": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "prop1": "match"
+                },
+                "description": "referenced subschema doesn't see annotations from properties",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "$defs": {
+                "a_string": {
+                    "type": "string"
+                }
+            },
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "enum": [
+                {
+                    "$ref": "#/$defs/a_string"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "data": "this is a string",
+                "description": "do not evaluate the $ref inside the enum, matching any string",
+                "valid": false
+            },
+            {
+                "data": {
+                    "type": "string"
+                },
+                "description": "do not evaluate the $ref inside the enum, definition exact match",
+                "valid": false
+            },
+            {
+                "data": {
+                    "$ref": "#/$defs/a_string"
+                },
+                "description": "match the enum exactly",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "refs with relative uris and defs",
+        "schema": {
+            "$id": "http://example.com/schema-relative-uri-defs1.json",
+            "$ref": "schema-relative-uri-defs2.json",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "$id": "schema-relative-uri-defs2.json",
+                    "$ref": "#/$defs/inner"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "bar": "a",
+                    "foo": {
+                        "bar": 1
+                    }
+                },
+                "description": "invalid on inner field",
+                "valid": false
+            },
+            {
+                "data": {
+                    "bar": 1,
+                    "foo": {
+                        "bar": "a"
+                    }
+                },
+                "description": "invalid on outer field",
+                "valid": false
+            },
+            {
+                "data": {
+                    "bar": "a",
+                    "foo": {
+                        "bar": "a"
+                    }
+                },
+                "description": "valid on both fields",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative refs with absolute uris and defs",
+        "schema": {
+            "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
+            "$ref": "schema-refs-absolute-uris-defs2.json",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "$id": "http://example.com/schema-refs-absolute-uris-defs2.json",
+                    "$ref": "#/$defs/inner"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "bar": "a",
+                    "foo": {
+                        "bar": 1
+                    }
+                },
+                "description": "invalid on inner field",
+                "valid": false
+            },
+            {
+                "data": {
+                    "bar": 1,
+                    "foo": {
+                        "bar": "a"
+                    }
+                },
+                "description": "invalid on outer field",
+                "valid": false
+            },
+            {
+                "data": {
+                    "bar": "a",
+                    "foo": {
+                        "bar": "a"
+                    }
+                },
+                "description": "valid on both fields",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$defs": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "$defs": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "$id": "http://example.com/a.json",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "data": 1,
+                "description": "number is valid",
+                "valid": true
+            },
+            {
+                "data": "a",
+                "description": "non-number is invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $ref",
+        "schema": {
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /ref-and-id1/int.json",
+                    "$id": "int.json",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /ref-and-id1-int.json",
+                    "$id": "/draft2020-12/ref-and-id1-int.json",
+                    "maximum": 2
+                }
+            },
+            "$id": "/draft2020-12/ref-and-id1/base.json",
+            "$ref": "int.json",
+            "$schema": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "data": 5,
+                "description": "data is valid against first definition",
+                "valid": true
+            },
+            {
+                "data": 50,
+                "description": "data is invalid against first definition",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $anchor and $ref",
+        "schema": {
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$defs": {
+                "bigint": {
+                    "$anchor": "bigint",
+                    "$comment": "canonical uri: /ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$anchor": "bigint",
+                    "$comment": "canonical uri: /ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
+                    "$id": "/draft2020-12/ref-and-id2/",
+                    "maximum": 2
+                }
+            },
+            "$id": "/draft2020-12/ref-and-id2/base.json",
+            "$ref": "#bigint",
+            "$schema": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "data": 5,
+                "description": "data is valid against first definition",
+                "valid": true
+            },
+            {
+                "data": 50,
+                "description": "data is invalid against first definition",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with $ref via the URN",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "minimum": 30,
+            "properties": {
+                "foo": {
+                    "$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "foo": 37
+                },
+                "description": "valid under the URN IDed schema",
+                "valid": true
+            },
+            {
+                "data": {
+                    "foo": 12
+                },
+                "description": "invalid under the URN IDed schema",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with JSON pointer",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$defs": {
+                "bar": {
+                    "type": "string"
+                }
+            },
+            "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "foo": "bar"
+                },
+                "description": "a string is valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "foo": 12
+                },
+                "description": "a non-string is invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with NSS",
+        "schema": {
+            "$comment": "RFC 8141 §2.2",
+            "$defs": {
+                "bar": {
+                    "type": "string"
+                }
+            },
+            "$id": "urn:example:1/406/47452/2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "foo": "bar"
+                },
+                "description": "a string is valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "foo": 12
+                },
+                "description": "a non-string is invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with r-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.1",
+            "$defs": {
+                "bar": {
+                    "type": "string"
+                }
+            },
+            "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "foo": "bar"
+                },
+                "description": "a string is valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "foo": 12
+                },
+                "description": "a non-string is invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with q-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.2",
+            "$defs": {
+                "bar": {
+                    "type": "string"
+                }
+            },
+            "$id": "urn:example:weather?=op=map\u0026lat=39.56\u0026lon=-104.85\u0026datetime=1969-07-21T02:56:15Z",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "foo": "bar"
+                },
+                "description": "a string is valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "foo": 12
+                },
+                "description": "a non-string is invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with f-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.3, but we don't allow fragments",
+            "$ref": "https://json-schema.org/draft/2020-12/schema",
+            "$schema": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "data": {
+                    "$id": "urn:example:foo-bar-baz-qux#somepart"
+                },
+                "description": "is invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and JSON pointer ref",
+        "schema": {
+            "$defs": {
+                "bar": {
+                    "type": "string"
+                }
+            },
+            "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "foo": "bar"
+                },
+                "description": "a string is valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "foo": 12
+                },
+                "description": "a non-string is invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and anchor ref",
+        "schema": {
+            "$defs": {
+                "bar": {
+                    "$anchor": "something",
+                    "type": "string"
+                }
+            },
+            "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {
+                    "$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"
+                }
+            }
+        },
+        "tests": [
+            {
+                "data": {
+                    "foo": "bar"
+                },
+                "description": "a string is valid",
+                "valid": true
+            },
+            {
+                "data": {
+                    "foo": 12
+                },
+                "description": "a non-string is invalid",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN ref with nested pointer ref",
+        "schema": {
+            "$defs": {
+                "foo": {
+                    "$defs": {
+                        "bar": {
+                            "type": "string"
+                        }
+                    },
+                    "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+                    "$ref": "#/$defs/bar"
+                }
+            },
+            "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed"
+        },
+        "tests": [
+            {
+                "data": "bar",
+                "description": "a string is valid",
+                "valid": true
+            },
+            {
+                "data": 12,
+                "description": "a non-string is invalid",
+                "valid": false
+            }
+        ]
+    }
+]

--- a/pkg/normalize/testdata/3.json
+++ b/pkg/normalize/testdata/3.json
@@ -1,0 +1,887 @@
+[
+    {
+        "description": "root pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"$ref": "#"}
+            },
+            "additionalProperties": false
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"foo": false},
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": {"foo": {"foo": false}},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": false},
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": {"foo": {"bar": false}},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to object",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo": {"type": "integer"},
+                "bar": {"$ref": "#/properties/foo"}
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": {"bar": 3},
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": {"bar": true},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "relative pointer ref to array",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "prefixItems": [
+                {"type": "integer"},
+                {"$ref": "#/prefixItems/0"}
+            ]
+        },
+        "tests": [
+            {
+                "description": "match array",
+                "data": [1, 2],
+                "valid": true
+            },
+            {
+                "description": "mismatch array",
+                "data": [1, "foo"],
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "escaped pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "tilde~field": {"type": "integer"},
+                "slash/field": {"type": "integer"},
+                "percent%field": {"type": "integer"}
+            },
+            "properties": {
+                "tilde": {"$ref": "#/$defs/tilde~0field"},
+                "slash": {"$ref": "#/$defs/slash~1field"},
+                "percent": {"$ref": "#/$defs/percent%25field"}
+            }
+        },
+        "tests": [
+            {
+                "description": "slash invalid",
+                "data": {"slash": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "tilde invalid",
+                "data": {"tilde": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "percent invalid",
+                "data": {"percent": "aoeu"},
+                "valid": false
+            },
+            {
+                "description": "slash valid",
+                "data": {"slash": 123},
+                "valid": true
+            },
+            {
+                "description": "tilde valid",
+                "data": {"tilde": 123},
+                "valid": true
+            },
+            {
+                "description": "percent valid",
+                "data": {"percent": 123},
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "nested refs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "a": {"type": "integer"},
+                "b": {"$ref": "#/$defs/a"},
+                "c": {"$ref": "#/$defs/b"}
+            },
+            "$ref": "#/$defs/c"
+        },
+        "tests": [
+            {
+                "description": "nested ref valid",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "nested ref invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref applies alongside sibling keywords",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "reffed": {
+                    "type": "array"
+                }
+            },
+            "properties": {
+                "foo": {
+                    "$ref": "#/$defs/reffed",
+                    "maxItems": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "ref valid, maxItems valid",
+                "data": { "foo": [] },
+                "valid": true
+            },
+            {
+                "description": "ref valid, maxItems invalid",
+                "data": { "foo": [1, 2, 3] },
+                "valid": false
+            },
+            {
+                "description": "ref invalid",
+                "data": { "foo": "string" },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "remote ref, containing refs itself",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "remote ref valid",
+                "data": {"minLength": 1},
+                "valid": true
+            },
+            {
+                "description": "remote ref invalid",
+                "data": {"minLength": -1},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref that is not a reference",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "$ref": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "property named $ref, containing an actual $ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "$ref": {"$ref": "#/$defs/is-string"}
+            },
+            "$defs": {
+                "is-string": {
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "property named $ref valid",
+                "data": {"$ref": "a"},
+                "valid": true
+            },
+            {
+                "description": "property named $ref invalid",
+                "data": {"$ref": 2},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema true",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {
+                "bool": true
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is valid",
+                "data": "foo",
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$ref to boolean schema false",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "#/$defs/bool",
+            "$defs": {
+                "bool": false
+            }
+        },
+        "tests": [
+            {
+                "description": "any value is invalid",
+                "data": "foo",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "Recursive references between schemas",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://localhost:1234/draft2020-12/tree",
+            "description": "tree of nodes",
+            "type": "object",
+            "properties": {
+                "meta": {"type": "string"},
+                "nodes": {
+                    "type": "array",
+                    "items": {"$ref": "node"}
+                }
+            },
+            "required": ["meta", "nodes"],
+            "$defs": {
+                "node": {
+                    "$id": "http://localhost:1234/draft2020-12/node",
+                    "description": "node",
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "number"},
+                        "subtree": {"$ref": "tree"}
+                    },
+                    "required": ["value"]
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "valid tree",
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 1.1},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": true
+            },
+            {
+                "description": "invalid tree",
+                "data": {
+                    "meta": "root",
+                    "nodes": [
+                        {
+                            "value": 1,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": "string is invalid"},
+                                    {"value": 1.2}
+                                ]
+                            }
+                        },
+                        {
+                            "value": 2,
+                            "subtree": {
+                                "meta": "child",
+                                "nodes": [
+                                    {"value": 2.1},
+                                    {"value": 2.2}
+                                ]
+                            }
+                        }
+                    ]
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "refs with quote",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "properties": {
+                "foo\"bar": {"$ref": "#/$defs/foo%22bar"}
+            },
+            "$defs": {
+                "foo\"bar": {"type": "number"}
+            }
+        },
+        "tests": [
+            {
+                "description": "object with numbers is valid",
+                "data": {
+                    "foo\"bar": 1
+                },
+                "valid": true
+            },
+            {
+                "description": "object with strings is invalid",
+                "data": {
+                    "foo\"bar": "1"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "ref creates new scope when adjacent to keywords",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "A": {
+                    "unevaluatedProperties": false
+                }
+            },
+            "properties": {
+                "prop1": {
+                    "type": "string"
+                }
+            },
+            "$ref": "#/$defs/A"
+        },
+        "tests": [
+            {
+                "description": "referenced subschema doesn't see annotations from properties",
+                "data": {
+                    "prop1": "match"
+                },
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "naive replacement of $ref with its destination is not correct",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$defs": {
+                "a_string": { "type": "string" }
+            },
+            "enum": [
+                { "$ref": "#/$defs/a_string" }
+            ]
+        },
+        "tests": [
+            {
+                "description": "do not evaluate the $ref inside the enum, matching any string",
+                "data": "this is a string",
+                "valid": false
+            },
+            {
+                "description": "do not evaluate the $ref inside the enum, definition exact match",
+                "data": { "type": "string" },
+                "valid": false
+            },
+            {
+                "description": "match the enum exactly",
+                "data": { "$ref": "#/$defs/a_string" },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "refs with relative uris and defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/schema-relative-uri-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "schema-relative-uri-defs2.json",
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "$ref": "#/$defs/inner"
+                }
+            },
+            "$ref": "schema-relative-uri-defs2.json"
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "relative refs with absolute uris and defs",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/schema-refs-absolute-uris-defs1.json",
+            "properties": {
+                "foo": {
+                    "$id": "http://example.com/schema-refs-absolute-uris-defs2.json",
+                    "$defs": {
+                        "inner": {
+                            "properties": {
+                                "bar": { "type": "string" }
+                            }
+                        }
+                    },
+                    "$ref": "#/$defs/inner"
+                }
+            },
+            "$ref": "schema-refs-absolute-uris-defs2.json"
+        },
+        "tests": [
+            {
+                "description": "invalid on inner field",
+                "data": {
+                    "foo": {
+                        "bar": 1
+                    },
+                    "bar": "a"
+                },
+                "valid": false
+            },
+            {
+                "description": "invalid on outer field",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": 1
+                },
+                "valid": false
+            },
+            {
+                "description": "valid on both fields",
+                "data": {
+                    "foo": {
+                        "bar": "a"
+                    },
+                    "bar": "a"
+                },
+                "valid": true
+            }
+        ]
+    },
+    {
+        "description": "$id must be resolved against nearest parent, not just immediate parent",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "http://example.com/a.json",
+            "$defs": {
+                "x": {
+                    "$id": "http://example.com/b/c.json",
+                    "not": {
+                        "$defs": {
+                            "y": {
+                                "$id": "d.json",
+                                "type": "number"
+                            }
+                        }
+                    }
+                }
+            },
+            "allOf": [
+                {
+                    "$ref": "http://example.com/b/d.json"
+                }
+            ]
+        },
+        "tests": [
+            {
+                "description": "number is valid",
+                "data": 1,
+                "valid": true
+            },
+            {
+                "description": "non-number is invalid",
+                "data": "a",
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $ref",
+        "schema": {
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "/draft2020-12/ref-and-id1/base.json",
+            "$ref": "int.json",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /ref-and-id1/int.json",
+                    "$id": "int.json",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /ref-and-id1-int.json",
+                    "$id": "/draft2020-12/ref-and-id1-int.json",
+                    "maximum": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is valid against first definition",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "data is invalid against first definition",
+                "data": 50,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "order of evaluation: $id and $anchor and $ref",
+        "schema": {
+            "$comment": "$id must be evaluated before $ref to get the proper $ref destination",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "/draft2020-12/ref-and-id2/base.json",
+            "$ref": "#bigint",
+            "$defs": {
+                "bigint": {
+                    "$comment": "canonical uri: /ref-and-id2/base.json#/$defs/bigint; another valid uri for this location: /ref-and-id2/base.json#bigint",
+                    "$anchor": "bigint",
+                    "maximum": 10
+                },
+                "smallint": {
+                    "$comment": "canonical uri: /ref-and-id2#/$defs/smallint; another valid uri for this location: /ref-and-id2/#bigint",
+                    "$id": "/draft2020-12/ref-and-id2/",
+                    "$anchor": "bigint",
+                    "maximum": 2
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "data is valid against first definition",
+                "data": 5,
+                "valid": true
+            },
+            {
+                "description": "data is invalid against first definition",
+                "data": 50,
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with $ref via the URN",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed",
+            "minimum": 30,
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ffff-ffff-4321feebdaed"}
+            }
+        },
+        "tests": [
+            {
+                "description": "valid under the URN IDed schema",
+                "data": {"foo": 37},
+                "valid": true
+            },
+            {
+                "description": "invalid under the URN IDed schema",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "simple URN base URI with JSON pointer",
+        "schema": {
+            "$comment": "URIs do not have to have HTTP(s) schemes",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-00ff-ff00-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with NSS",
+        "schema": {
+            "$comment": "RFC 8141 §2.2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:1/406/47452/2",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with r-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.1",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:foo-bar-baz-qux?+CCResolve:cc=uk",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with q-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.2",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:example:weather?=op=map&lat=39.56&lon=-104.85&datetime=1969-07-21T02:56:15Z",
+            "properties": {
+                "foo": {"$ref": "#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with f-component",
+        "schema": {
+            "$comment": "RFC 8141 §2.3.3, but we don't allow fragments",
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://json-schema.org/draft/2020-12/schema"
+        },
+        "tests": [
+            {
+                "description": "is invalid",
+                "data": {"$id": "urn:example:foo-bar-baz-qux#somepart"},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and JSON pointer ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-0000-0000-4321feebdaed#/$defs/bar"}
+            },
+            "$defs": {
+                "bar": {"type": "string"}
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN base URI with URN and anchor ref",
+        "schema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed",
+            "properties": {
+                "foo": {"$ref": "urn:uuid:deadbeef-1234-ff00-00ff-4321feebdaed#something"}
+            },
+            "$defs": {
+                "bar": {
+                    "$anchor": "something",
+                    "type": "string"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": {"foo": "bar"},
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": {"foo": 12},
+                "valid": false
+            }
+        ]
+    },
+    {
+        "description": "URN ref with nested pointer ref",
+        "schema": {
+            "$ref": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+            "$defs": {
+                "foo": {
+                    "$id": "urn:uuid:deadbeef-4321-ffff-ffff-1234feebdaed",
+                    "$defs": {"bar": {"type": "string"}},
+                    "$ref": "#/$defs/bar"
+                }
+            }
+        },
+        "tests": [
+            {
+                "description": "a string is valid",
+                "data": "bar",
+                "valid": true
+            },
+            {
+                "description": "a non-string is invalid",
+                "data": 12,
+                "valid": false
+            }
+        ]
+    }
+]

--- a/pkg/normalize/testdata/4.golden
+++ b/pkg/normalize/testdata/4.golden
@@ -1,0 +1,6 @@
+{
+    "$id": "http://example.com/myschema",
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {},
+    "type": "object"
+}

--- a/pkg/normalize/testdata/4.json
+++ b/pkg/normalize/testdata/4.json
@@ -1,0 +1,6 @@
+{
+"$schema": "http://json-schema.org/schema#",
+"type": "object",
+"properties": {},
+"$id": "http://example.com/myschema"
+}

--- a/pkg/normalize/testdata/5.golden
+++ b/pkg/normalize/testdata/5.golden
@@ -1,0 +1,6 @@
+{
+    "$id": "http://example.com/myschema",
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {},
+    "type": "object"
+}

--- a/pkg/normalize/testdata/5.json
+++ b/pkg/normalize/testdata/5.json
@@ -1,0 +1,6 @@
+{
+    "$id": "http://example.com/myschema",
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {},
+    "type": "object"
+}

--- a/pkg/normalize/testdata/6.txt
+++ b/pkg/normalize/testdata/6.txt
@@ -1,0 +1,1 @@
+# This is not JSON

--- a/pkg/normalize/testdata/7.golden
+++ b/pkg/normalize/testdata/7.golden
@@ -1,0 +1,3 @@
+{
+    "key": "value two"
+}

--- a/pkg/normalize/testdata/7.json
+++ b/pkg/normalize/testdata/7.json
@@ -1,0 +1,4 @@
+{
+    "key": "value one",
+    "key": "value two"
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1733

This PR

- adds a command that can be used to normalize a JSON schema file. The goal is to maintain schema in a way that avoids any changes bearing no meaning, like ordering and white space.
- Moved the validation function from the root command into the `verify` command. Because it's not possible to have both `schemalint PATH` and `schemalint normalize PATH`.

The normalization rules are basic and rely on what Go's `encoding/json` mechanics do when marshalling JSON with indentation.

## Usage examples:

```nohighlight
$ schemalint normalize ./pkg/normalize/testdata/4.json > normalized.json
```

```nohighlight
$ schemalint normalize ./LICENSE > normalized.json
Error processing file ./LICENSE.
Probably this is not valid JSON.
Details: invalid character 'A' looking for beginning of value
```