### PR TITLE
Allow for exactly one path argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Move linting function from root command into `verify` command (breaking).
 - Add `normalize` command.
+- Avoid double error output.
+- Quit with error if users gives multiple positional arguments to the `verify` and `normalize` command.
 
 ## [0.0.2] - 2022-12-05
 

--- a/cmd/normalize.go
+++ b/cmd/normalize.go
@@ -19,7 +19,7 @@ var (
 
 The normalized JSON will be printed to STDOUT.`,
 		Example:      `  schemalint path/to/schema.json > normalized.json`,
-		Args:         cobra.MinimumNArgs(1),
+		Args:         cobra.ExactArgs(1),
 		ArgAliases:   []string{"PATH"},
 		Run:          normalizeRun,
 		SilenceUsage: true,

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -12,7 +12,7 @@ var (
 	verifyCmd = &cobra.Command{
 		Use:          "verify PATH",
 		Short:        "Verify the given JSON schema input",
-		Args:         cobra.MinimumNArgs(1),
+		Args:         cobra.ExactArgs(1),
 		ArgAliases:   []string{"PATH"},
 		Run:          verifyRun,
 		SilenceUsage: true,

--- a/main.go
+++ b/main.go
@@ -8,8 +8,5 @@ import (
 
 func main() {
 	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
-	err := cmd.Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
+	_ = cmd.Execute()
 }


### PR DESCRIPTION
### What does this PR do?

Restricts both commands to allow for exactly one positional argument.

### What is the effect of this change to users?

There is no change regarded the intended use.

However, if users called the command using a bad syntax, e. g. by providing a second path, so far this was ignored silently. This change makes it easier for users to spot their mistakes.

### How does it look like?

```nohighlight
$ schemalint verify first second
accepts 1 arg(s), received 2
```

### Do the docs need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated (if it exists)