### PR TITLE
Fix `normalize`: avoid extra line break at end of output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix `normalize`: avoid extra line break at end of output.
+
 ## [0.1.0] - 2022-12-09
 
 - Move linting function from root command into `verify` command (breaking).

--- a/cmd/normalize.go
+++ b/cmd/normalize.go
@@ -38,5 +38,7 @@ func normalizeRun(cmd *cobra.Command, args []string) {
 		log.Fatalf("Error processing file %s.\nProbably this is not valid JSON.\nDetails: %s", path, err)
 	}
 
-	fmt.Println(string(output))
+	// Print normalized to STDOUT.
+	// Caution: no extra white space must be added.
+	fmt.Print(string(output))
 }


### PR DESCRIPTION
### What does this PR do?

Fix the problem detected by @mogottsch in https://github.com/giantswarm/schemalint/pull/7#pullrequestreview-1213010723

### What is the effect of this change to users?

Instead of `\n\n`, the `normalize` output will end in `\n`.

### Any background context you can provide?

No

### What is needed from the reviewers?

Nothing special

### Do the docs/README need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
