### PR TITLE
`normalize`: add option to set output path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `normalize`: add flags to write to output file path.
+
 ## [0.2.0] - 2022-12-12
 
 - Extend `verify` command to also check normalization.

--- a/README.md
+++ b/README.md
@@ -29,3 +29,5 @@ Create a normalized (white space, sorting) representation of a JSON Schema file.
 ```nohighlight
 $ schemalint normalize myschema.json > normalized.json
 ```
+
+Use `--help` to learn about more options.

--- a/cmd/normalize.go
+++ b/cmd/normalize.go
@@ -64,7 +64,7 @@ func normalizeRun(cmd *cobra.Command, args []string) {
 
 	// Write output.
 	if outputPath != "" {
-		err := os.WriteFile(outputPath, output, 0644)
+		err := os.WriteFile(outputPath, output, 0600)
 		if err != nil {
 			log.Fatalf("Error writing to file: %s", err)
 		} else {

--- a/cmd/normalize.go
+++ b/cmd/normalize.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -17,16 +18,39 @@ var (
 		Aliases: []string{"normalise", "norm"},
 		Long: `Normalize the given JSON schema input.
 
-The normalized JSON will be printed to STDOUT.`,
-		Example:      `  schemalint path/to/schema.json > normalized.json`,
+By default, the normalized JSON will be printed to STDOUT. Use
+--output-path / -o to specify a target path. To overwrite an
+existing file, add --force.
+`,
+		Example: `  schemalint normalize schema.json > normalized.json
+
+  schemalint normalize schema.json -o normalized.json
+
+  schemalint normalize in.json -o in.json --force
+`,
 		Args:         cobra.ExactArgs(1),
 		ArgAliases:   []string{"PATH"},
 		Run:          normalizeRun,
 		SilenceUsage: true,
 	}
+
+	outputPath     string
+	forceOverwrite bool
 )
 
+func init() {
+	normalizeCmd.Flags().StringVarP(&outputPath, "output-path", "o", "", "Output file path. If not set, STDOUT will be used.")
+	normalizeCmd.Flags().BoolVar(&forceOverwrite, "force", false, "Force overwriting any existing file when using --output-path/-o.")
+}
+
 func normalizeRun(cmd *cobra.Command, args []string) {
+	if outputPath != "" {
+		_, err := os.Stat(outputPath)
+		if !forceOverwrite && !errors.Is(err, os.ErrNotExist) {
+			log.Fatal("Error: output file already exists. Apply --force to overwrite.")
+		}
+	}
+
 	path := args[0]
 	input, err := os.ReadFile(path)
 	if err != nil {
@@ -38,7 +62,17 @@ func normalizeRun(cmd *cobra.Command, args []string) {
 		log.Fatalf("Error processing file %s.\nProbably this is not valid JSON.\nDetails: %s", path, err)
 	}
 
-	// Print normalized to STDOUT.
-	// Caution: no extra white space must be added.
-	fmt.Print(string(output))
+	// Write output.
+	if outputPath != "" {
+		err := os.WriteFile(outputPath, output, 0644)
+		if err != nil {
+			log.Fatalf("Error writing to file: %s", err)
+		} else {
+			fmt.Printf("Normalized output written to %s.\n", outputPath)
+		}
+	} else {
+		// Print normalized to STDOUT.
+		// Caution: no extra white space must be added.
+		fmt.Print(string(output))
+	}
 }

--- a/out.json
+++ b/out.json
@@ -1,0 +1,10 @@
+{
+    "$id": "http://example.com/myschema",
+    "$schema": "http://json-schema.org/schema#",
+    "properties": {
+        "foo": {
+            "title": "foo"
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds options to the `normalize` command to set an output file path, which also allows to overwrite the input file in one command.

### What is the effect of this change to users?

Syntax from previous version still works unmodified.

### How does it look like?

`--help` output:

```nohighlight
Normalize the given JSON schema input.

By default, the normalized JSON will be printed to STDOUT. Use
--output-path / -o to specify a target path. To overwrite an
existing file, add --force.

Usage:
  schemalint normalize PATH [flags]

Aliases:
  normalize, normalise, norm

Examples:
  schemalint normalize schema.json > normalized.json

  schemalint normalize schema.json -o normalized.json

  schemalint normalize in.json -o in.json --force

Flags:
      --force                Force overwriting any existing file when using --output-path/-o.
  -h, --help                 help for normalize
  -o, --output-path string   Output file path. If not set, STDOUT will be used.
```

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/1733

### What is needed from the reviewers?

n/a

### Do the docs/README need to be updated?

Done

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
