### PR TITLE
Show possible values of rule-set in --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add possible values of `rule-set` to `--help` message
+
 ## [0.3.0] - 2023-01-12
 
 - `normalize`: add flags to write to output file path.
@@ -32,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added first basic linting.
 
-[Unreleased]: https://github.com/giantswarm/schemalint/compare/v0.3.0...HEAD
+[unreleased]: https://github.com/giantswarm/schemalint/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/giantswarm/schemalint/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/giantswarm/schemalint/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/giantswarm/schemalint/compare/v0.0.2...v0.1.0

--- a/cmd/verify/flag.go
+++ b/cmd/verify/flag.go
@@ -2,6 +2,7 @@ package verify
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -16,9 +17,10 @@ type flag struct {
 }
 
 func (f *flag) init(cmd *cobra.Command) {
+	ruleSets := rulesets.GetAvailableRuleSetsAsStrings()
 	cmd.Flags().BoolVar(&f.skipNormalization, "skip-normalization", false, "Disable the normalization check.")
 	cmd.Flags().BoolVar(&f.skipSchemaValidation, "skip-schema-validation", false, "Disable the JSON schema validation.")
-	cmd.Flags().StringVar(&f.ruleSet, "rule-set", "", "The rule set to use for validation.")
+	cmd.Flags().StringVar(&f.ruleSet, "rule-set", "", "The rule set to use for validation. Available rule sets are: "+strings.Join(ruleSets, ", "))
 }
 
 func (f *flag) validate() []error {

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -37,6 +37,15 @@ func GetAvailableRuleSets() []RuleSetName {
 	return ruleSets
 }
 
+func GetAvailableRuleSetsAsStrings() []string {
+	ruleSets := GetAvailableRuleSets()
+	stringRuleSets := []string{}
+	for _, ruleSet := range ruleSets {
+		stringRuleSets = append(stringRuleSets, string(ruleSet))
+	}
+	return stringRuleSets
+}
+
 func IsRuleSetName(name string) bool {
 	for _, ruleSet := range GetAvailableRuleSets() {
 		if ruleSet == RuleSetName(name) {


### PR DESCRIPTION
### What does this PR do?

See title.

### What is the effect of this change to users?

Users will be able to use rule-sets without guessing.

### How does it look like?

```
❯ go run ./main.go verify --help
Verify the given JSON schema input

Usage:
  schemalint verify PATH [flags]

Flags:
  -h, --help                     help for verify
      --rule-set string          The rule set to use for validation. Available rule sets are: cluster-app
      --skip-normalization       Disable the normalization check.
      --skip-schema-validation   Disable the JSON schema validation.

```

### Any background context you can provide?

closes https://github.com/giantswarm/roadmap/issues/1858

### Do the docs/README need to be updated?

No.

### Should this change be mentioned in the release notes?

- [X] CHANGELOG.md has been updated
