### PR TITLE
Wrap all tests in t.Run

### DIFF
--- a/cmd/normalize/flag_test.go
+++ b/cmd/normalize/flag_test.go
@@ -33,16 +33,18 @@ func TestValidateFlags(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		flag := &flag{
-			outputPath:     tc.outputPath,
-			forceOverwrite: tc.forceOverwrite,
-		}
-		err := flag.validate()
-		if err != nil && !tc.expectedError {
-			t.Fatalf("Unexpected error in test case '%s': %s", tc.name, err)
-		}
-		if err == nil && tc.expectedError {
-			t.Fatalf("Expected error, got none in test case '%s'", tc.name)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			flag := &flag{
+				outputPath:     tc.outputPath,
+				forceOverwrite: tc.forceOverwrite,
+			}
+			err := flag.validate()
+			if err != nil && !tc.expectedError {
+				t.Fatalf("Unexpected error in test case '%s': %s", tc.name, err)
+			}
+			if err == nil && tc.expectedError {
+				t.Fatalf("Expected error, got none in test case '%s'", tc.name)
+			}
+		})
 	}
 }

--- a/cmd/verify/flag_test.go
+++ b/cmd/verify/flag_test.go
@@ -45,19 +45,21 @@ func TestValidateFlags(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		flag := &flag{
-			ruleSet:              tc.ruleSet,
-			skipNormalization:    tc.skipNormalization,
-			skipSchemaValidation: tc.skipSchemaValidation,
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			flag := &flag{
+				ruleSet:              tc.ruleSet,
+				skipNormalization:    tc.skipNormalization,
+				skipSchemaValidation: tc.skipSchemaValidation,
+			}
 
-		err := flag.validate()
+			err := flag.validate()
 
-		if err != nil && !tc.expectedError {
-			t.Fatalf("Unexpected error in test case '%s': %s", tc.name, err)
-		}
-		if err == nil && tc.expectedError {
-			t.Fatalf("Expected error, got none in test case '%s'", tc.name)
-		}
+			if err != nil && !tc.expectedError {
+				t.Fatalf("Unexpected error in test case '%s': %s", tc.name, err)
+			}
+			if err == nil && tc.expectedError {
+				t.Fatalf("Expected error, got none in test case '%s'", tc.name)
+			}
+		})
 	}
 }

--- a/pkg/lint/rulesmeta/rules/description_exists_test.go
+++ b/pkg/lint/rulesmeta/rules/description_exists_test.go
@@ -25,15 +25,17 @@ func TestDescriptionExists(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		schema, err := lint.Compile(tc.schemaPath)
-		if err != nil {
-			t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
-		}
-		descriptionExistsRule := DescriptionExists{}
-		ruleViolations := descriptionExistsRule.Verify(schema)
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+			descriptionExistsRule := DescriptionExists{}
+			ruleViolations := descriptionExistsRule.Verify(schema)
 
-		if len(ruleViolations) != tc.nViolations {
-			t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleViolations))
-		}
+			if len(ruleViolations) != tc.nViolations {
+				t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleViolations))
+			}
+		})
 	}
 }

--- a/pkg/lint/rulesmeta/rules/title_exists_test.go
+++ b/pkg/lint/rulesmeta/rules/title_exists_test.go
@@ -25,15 +25,17 @@ func TestTitleExists(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		schema, err := lint.Compile(tc.schemaPath)
-		if err != nil {
-			t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
-		}
-		titleExistsRule := TitleExists{}
-		ruleViolations := titleExistsRule.Verify(schema)
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+			titleExistsRule := TitleExists{}
+			ruleViolations := titleExistsRule.Verify(schema)
 
-		if len(ruleViolations) != tc.nViolations {
-			t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleViolations))
-		}
+			if len(ruleViolations) != tc.nViolations {
+				t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleViolations))
+			}
+		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds a call to `t.Run` to all table-based tests. Without this we cannot see if multiple test cases of the same test are failing at the same time.

### What is the effect of this change to users?

None.

### How does it look like?

(Please add anything that represents the change visually. Screenshots, output, logs, ...)
**old**:
```
❯ go test ./...
--- FAIL: TestDescriptionCorrect (0.00s)
    description_correct_test.go:102: Unexpected number of rule violations in test case 'description contains line breaks': Expected 2, got 0
FAIL

```
**new**:
```
❯ go test ./...
--- FAIL: TestDescriptionCorrect (0.00s)
    --- FAIL: TestDescriptionCorrect/description_contains_line_breaks (0.00s)
        description_correct_test.go:103: Unexpected number of rule violations in test case 'description contains line breaks': Expected 2, got 0
    --- FAIL: TestDescriptionCorrect/description_is_not_sentence_case (0.00s)
        description_correct_test.go:103: Unexpected number of rule violations in test case 'description is not sentence case': Expected 1, got 0
    --- FAIL: TestDescriptionCorrect/all_rules_fail (0.00s)
        description_correct_test.go:103: Unexpected number of rule violations in test case 'all rules fail': Expected 5, got 3
FAIL
```


### Any background context you can provide?

No.

### What is needed from the reviewers?

Verify that this is the correct way to write tests in go.

### Do the docs/README need to be updated?

No.

### Should this change be mentioned in the release notes?

No.