### PR TITLE
Add rules for correctness of description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add check that an existing title follows requirements as defined in [this RFC](https://github.com/giantswarm/rfc/pull/55).
+
 ## [0.5.0] - 2023-01-30
 
 - Resolve schemas referenced through the `$ref` keyword while checking rules.

--- a/pkg/lint/rules/description_must_be_sentence_case.go
+++ b/pkg/lint/rules/description_must_be_sentence_case.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"fmt"
-	"unicode"
 
 	"github.com/giantswarm/schemalint/pkg/lint"
 	"github.com/giantswarm/schemalint/pkg/lint/utils"
@@ -17,17 +16,12 @@ func (r DescriptionMustBeSentenceCase) Verify(schema *schemautils.ExtendedSchema
 	propertyAnnotationsMap := utils.BuildPropertyAnnotationsMap(schema).WhereDescriptionsExist()
 
 	for path, annotations := range propertyAnnotationsMap {
-		if !descriptionStartsCapitalized(annotations.GetDescription()) {
+		if !stringStartsCapitalized(annotations.GetDescription()) {
 			ruleResults.Add(fmt.Sprintf("Property '%s' description must start with a capital letter.", path))
 		}
 	}
 
 	return *ruleResults
-}
-
-func descriptionStartsCapitalized(description string) bool {
-	return unicode.IsUpper(rune(description[0]))
-
 }
 
 func (r DescriptionMustBeSentenceCase) GetSeverity() lint.Severity {

--- a/pkg/lint/rules/description_must_not_contain_illegal_characters.go
+++ b/pkg/lint/rules/description_must_not_contain_illegal_characters.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/giantswarm/schemalint/pkg/lint"
 	"github.com/giantswarm/schemalint/pkg/lint/utils"
@@ -20,28 +19,14 @@ func (r DescriptionMustNotContainIllegalCharacters) Verify(schema *schemautils.E
 
 	for path, annotations := range propertyAnnotationsMap {
 		description := annotations.GetDescription()
-		if containedIllegalChars := getIllegalCharacterIn(description); len(containedIllegalChars) > 0 {
-			ruleResults.Add(fmt.Sprintf("Property '%s' description must not contain illegal characters: %s", path, containedIllegalChars))
+		if containedIllegalChars := getIllegalCharacterIn(description, descriptionIllegalCharacters); len(containedIllegalChars) > 0 {
+			ruleResults.Add(fmt.Sprintf("Property '%s' description must not contain illegal characters: %q", path, containedIllegalChars))
 		}
 		if containsLeadingOrTrailingSpace(description) {
 			ruleResults.Add(fmt.Sprintf("Property '%s' description must not contain leading or trailing spaces", path))
 		}
 	}
 	return *ruleResults
-}
-
-func getIllegalCharacterIn(s string) (containedIllegalCharacters []string) {
-	for _, illegalCharacter := range descriptionIllegalCharacters {
-		if strings.Contains(s, illegalCharacter) {
-			containedIllegalCharacters = append(containedIllegalCharacters, illegalCharacter)
-		}
-	}
-
-	return containedIllegalCharacters
-}
-
-func containsLeadingOrTrailingSpace(s string) bool {
-	return strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ")
 }
 
 func (r DescriptionMustNotContainIllegalCharacters) GetSeverity() lint.Severity {

--- a/pkg/lint/rules/testdata/title_all_rules_fail.json
+++ b/pkg/lint/rules/testdata/title_all_rules_fail.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "properties": {
+    "cluster": {
+      "title": "Cluster",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": " cluster name\n\t."
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/pkg/lint/rules/testdata/title_contains_parents_title.json
+++ b/pkg/lint/rules/testdata/title_contains_parents_title.json
@@ -1,0 +1,15 @@
+{
+  "properties": {
+    "controlPlane": {
+      "properties": {
+        "availabilityZones": {
+          "type": "string",
+          "title": "Control Plane Availability Zones"
+        }
+      },
+      "title": "Control Plane",
+      "type": "object"
+    }
+  },
+  "type": "object"
+}

--- a/pkg/lint/rules/testdata/title_correct.json
+++ b/pkg/lint/rules/testdata/title_correct.json
@@ -1,0 +1,16 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "properties": {
+    "cluster": {
+      "title": "Cluster",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name"
+        }
+      }
+    }
+  },
+  "type": "object"
+}

--- a/pkg/lint/rules/testdata/title_not_sentence_case.json
+++ b/pkg/lint/rules/testdata/title_not_sentence_case.json
@@ -1,0 +1,10 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "properties": {
+    "lastName": {
+      "title": "cluster name",
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/pkg/lint/rules/testdata/title_with_illegal_chars.json
+++ b/pkg/lint/rules/testdata/title_with_illegal_chars.json
@@ -1,0 +1,46 @@
+{
+  "$id": "https://example.com/person.schema.json",
+  "properties": {
+    "firstName": {
+      "title": "First name!",
+      "type": "string"
+    },
+    "secondName": {
+      "title": "Cluster name.",
+      "type": "string"
+    },
+    "thirdName": {
+      "title": "First name?",
+      "type": "string"
+    },
+    "fourthName": {
+      "title": "First name,",
+      "type": "string"
+    },
+    "fifthName": {
+      "title": "First name ",
+      "type": "string"
+    },
+    "sixthName": {
+      "title": " First name",
+      "type": "string"
+    },
+    "seventhName": {
+      "title": "First name\n",
+      "type": "string"
+    },
+    "eighthName": {
+      "title": "First name\t",
+      "type": "string"
+    },
+    "ninthName": {
+      "title": "First  name",
+      "type": "string"
+    },
+    "tenthName": {
+      "title": "First name\r",
+      "type": "string"
+    }
+  },
+  "type": "object"
+}

--- a/pkg/lint/rules/title_correct_test.go
+++ b/pkg/lint/rules/title_correct_test.go
@@ -30,7 +30,7 @@ func TestTitleCorrect(t *testing.T) {
 			name:        "title is should not contain the parents title",
 			schemaPath:  "testdata/title_contains_parents_title.json",
 			nViolations: 1,
-			rules:       []lint.Rule{TitleMustNotContainParentsTitle{}},
+			rules:       []lint.Rule{TitleShouldNotContainParentsTitle{}},
 		},
 		{
 			name:        "title is correct",
@@ -39,7 +39,7 @@ func TestTitleCorrect(t *testing.T) {
 			rules: []lint.Rule{
 				TitleMustNotContainIllegalCharacters{},
 				TitleMustBeSentenceCase{},
-				TitleMustNotContainParentsTitle{},
+				TitleShouldNotContainParentsTitle{},
 			},
 		},
 		{
@@ -49,7 +49,7 @@ func TestTitleCorrect(t *testing.T) {
 			rules: []lint.Rule{
 				TitleMustNotContainIllegalCharacters{},
 				TitleMustBeSentenceCase{},
-				TitleMustNotContainParentsTitle{},
+				TitleShouldNotContainParentsTitle{},
 			},
 		},
 	}

--- a/pkg/lint/rules/title_correct_test.go
+++ b/pkg/lint/rules/title_correct_test.go
@@ -1,0 +1,77 @@
+package rules
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+func TestTitleCorrect(t *testing.T) {
+	testCases := []struct {
+		name        string
+		schemaPath  string
+		nViolations int
+		rules       []lint.Rule
+	}{
+		{
+			name:        "title contains line breaks",
+			schemaPath:  "testdata/title_with_illegal_chars.json",
+			nViolations: 10,
+			rules:       []lint.Rule{TitleMustNotContainIllegalCharacters{}},
+		},
+		{
+			name:        "title is not sentence case",
+			schemaPath:  "testdata/title_not_sentence_case.json",
+			nViolations: 1,
+			rules:       []lint.Rule{TitleMustBeSentenceCase{}},
+		},
+		{
+			name:        "title is should not contain the parents title",
+			schemaPath:  "testdata/title_contains_parents_title.json",
+			nViolations: 1,
+			rules:       []lint.Rule{TitleMustNotContainParentsTitle{}},
+		},
+		{
+			name:        "title is correct",
+			schemaPath:  "testdata/title_correct.json",
+			nViolations: 0,
+			rules: []lint.Rule{
+				TitleMustNotContainIllegalCharacters{},
+				TitleMustBeSentenceCase{},
+				TitleMustNotContainParentsTitle{},
+			},
+		},
+		{
+			name:        "all rules fail",
+			schemaPath:  "testdata/title_all_rules_fail.json",
+			nViolations: 4,
+			rules: []lint.Rule{
+				TitleMustNotContainIllegalCharacters{},
+				TitleMustBeSentenceCase{},
+				TitleMustNotContainParentsTitle{},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+
+			ruleResults := []string{}
+			for _, rule := range tc.rules {
+				ruleResults = append(ruleResults, rule.Verify(schema).Violations...)
+			}
+
+			if len(ruleResults) != tc.nViolations {
+				for _, violation := range ruleResults {
+					fmt.Println(violation)
+				}
+				t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleResults))
+			}
+		})
+	}
+}

--- a/pkg/lint/rules/title_must_be_sentence_case.go
+++ b/pkg/lint/rules/title_must_be_sentence_case.go
@@ -1,0 +1,29 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type TitleMustBeSentenceCase struct{}
+
+func (r TitleMustBeSentenceCase) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+
+	propertyAnnotationsMap := utils.BuildPropertyAnnotationsMap(schema).WhereTitlesExist()
+
+	for path, annotations := range propertyAnnotationsMap {
+		if !stringStartsCapitalized(annotations.GetTitle()) {
+			ruleResults.Add(fmt.Sprintf("Property '%s' title must start with a capital letter.", path))
+		}
+	}
+
+	return *ruleResults
+}
+
+func (r TitleMustBeSentenceCase) GetSeverity() lint.Severity {
+	return lint.SeverityError
+}

--- a/pkg/lint/rules/title_must_not_contain_illegal_characters.go
+++ b/pkg/lint/rules/title_must_not_contain_illegal_characters.go
@@ -1,0 +1,34 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type TitleMustNotContainIllegalCharacters struct{}
+
+var titleIllegalCharacters = []string{"\n", "\r", "\t", "  ", ".", ",", "?", "!"}
+
+func (r TitleMustNotContainIllegalCharacters) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+
+	propertyAnnotationsMap := utils.BuildPropertyAnnotationsMap(schema).WhereTitlesExist()
+
+	for path, annotations := range propertyAnnotationsMap {
+		title := annotations.GetTitle()
+		if containedIllegalChars := getIllegalCharacterIn(title, titleIllegalCharacters); len(containedIllegalChars) > 0 {
+			ruleResults.Add(fmt.Sprintf(`Property '%s' title must not contain illegal characters: %q`, path, containedIllegalChars))
+		}
+		if containsLeadingOrTrailingSpace(title) {
+			ruleResults.Add(fmt.Sprintf("Property '%s' title must not contain leading or trailing spaces", path))
+		}
+	}
+	return *ruleResults
+}
+
+func (r TitleMustNotContainIllegalCharacters) GetSeverity() lint.Severity {
+	return lint.SeverityError
+}

--- a/pkg/lint/rules/title_must_not_contain_parents_title.go
+++ b/pkg/lint/rules/title_must_not_contain_parents_title.go
@@ -9,9 +9,9 @@ import (
 	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
-type TitleMustNotContainParentsTitle struct{}
+type TitleShouldNotContainParentsTitle struct{}
 
-func (r TitleMustNotContainParentsTitle) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+func (r TitleShouldNotContainParentsTitle) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
 	ruleResults := &lint.RuleResults{}
 
 	propertyAnnotationsMap := utils.BuildPropertyAnnotationsMap(schema).WhereTitlesExist()
@@ -31,6 +31,6 @@ func (r TitleMustNotContainParentsTitle) Verify(schema *schemautils.ExtendedSche
 	return *ruleResults
 }
 
-func (r TitleMustNotContainParentsTitle) GetSeverity() lint.Severity {
-	return lint.SeverityError
+func (r TitleShouldNotContainParentsTitle) GetSeverity() lint.Severity {
+	return lint.SeverityRecommendation
 }

--- a/pkg/lint/rules/title_must_not_contain_parents_title.go
+++ b/pkg/lint/rules/title_must_not_contain_parents_title.go
@@ -1,0 +1,36 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type TitleMustNotContainParentsTitle struct{}
+
+func (r TitleMustNotContainParentsTitle) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+
+	propertyAnnotationsMap := utils.BuildPropertyAnnotationsMap(schema).WhereTitlesExist()
+
+	for path, annotations := range propertyAnnotationsMap {
+		title := annotations.GetTitle()
+		parentTitle := propertyAnnotationsMap.GetParentAnnotations(path).GetTitle()
+
+		if parentTitle == "" {
+			continue
+		}
+
+		if strings.Contains(strings.ToLower(title), strings.ToLower(parentTitle)) {
+			ruleResults.Add(fmt.Sprintf("Property '%s' title must not contain parent title '%s'.", path, parentTitle))
+		}
+	}
+	return *ruleResults
+}
+
+func (r TitleMustNotContainParentsTitle) GetSeverity() lint.Severity {
+	return lint.SeverityError
+}

--- a/pkg/lint/rules/utils.go
+++ b/pkg/lint/rules/utils.go
@@ -1,0 +1,25 @@
+package rules
+
+import (
+	"strings"
+	"unicode"
+)
+
+func getIllegalCharacterIn(s string, illegalCharacters []string) (containedIllegalCharacters []string) {
+	for _, illegalCharacter := range illegalCharacters {
+		if strings.Contains(s, illegalCharacter) {
+			containedIllegalCharacters = append(containedIllegalCharacters, illegalCharacter)
+		}
+	}
+
+	return containedIllegalCharacters
+}
+
+func containsLeadingOrTrailingSpace(s string) bool {
+	return strings.HasPrefix(s, " ") || strings.HasSuffix(s, " ")
+}
+
+func stringStartsCapitalized(str string) bool {
+	return unicode.IsUpper(rune(str[0]))
+
+}

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -20,6 +20,9 @@ const (
 var ClusterApp = &RuleSet{
 	rules: []lint.Rule{
 		rules.TitleExists{},
+		rules.TitleMustBeSentenceCase{},
+		rules.TitleMustNotContainIllegalCharacters{},
+		rules.TitleShouldNotContainParentsTitle{},
 		rules.DescriptionExists{},
 		rules.DescriptionMustNotContainIllegalCharacters{},
 		rules.DescriptionMustBeSentenceCase{},

--- a/pkg/lint/utils/propertyannotations.go
+++ b/pkg/lint/utils/propertyannotations.go
@@ -83,6 +83,27 @@ func (pam PropertyAnnotationsMap) WhereDescriptionsExist() PropertyAnnotationsMa
 	return newMap
 }
 
+func (pam PropertyAnnotationsMap) WhereTitlesExist() PropertyAnnotationsMap {
+	newMap := NewPropertyAnnotationsMap()
+	for path, annotations := range pam {
+		if annotations.GetTitle() != "" {
+			newMap[path] = annotations
+		}
+	}
+	return newMap
+}
+
+func (pam PropertyAnnotationsMap) GetParentAnnotations(path string) *AnnotationsWithLevel {
+	parentPath := schemautils.GetParentPropertyPath(path)
+
+	annotations, ok := pam[parentPath]
+	if !ok {
+		return nil
+	}
+
+	return annotations
+}
+
 // Builds a map with all properties in the given schema, where the key is the
 // path to the property and the value are the annotations for that property.
 // <path> -> <annotations>

--- a/pkg/schemautils/schemautils.go
+++ b/pkg/schemautils/schemautils.go
@@ -27,7 +27,7 @@ func (schema *ExtendedSchema) GetRefSchema() *ExtendedSchema {
 
 	refSchema.Parent = schema
 	refSchema.ParentPath = schema.GetResolvedLocation()
-	refSchema.TrimFromLocation = RemoveIdFromLocation(schema.Ref.Location)
+	refSchema.TrimFromLocation = removeIdFromLocation(schema.Ref.Location)
 
 	return refSchema
 }
@@ -68,14 +68,14 @@ func (schema *ExtendedSchema) GetConciseLocation() string {
 
 // Gets the location, excluding ids, including potential parent schemas
 func (schema *ExtendedSchema) GetResolvedLocation() string {
-	location := RemoveIdFromLocation(schema.Location)
+	location := removeIdFromLocation(schema.Location)
 	if schema.TrimFromLocation != "" {
 		location = strings.Replace(location, schema.TrimFromLocation, "", 1)
 	}
 	return schema.ParentPath + location
 }
 
-func RemoveIdFromLocation(location string) string {
+func removeIdFromLocation(location string) string {
 	return strings.Split(location, "#")[1]
 }
 
@@ -86,7 +86,7 @@ func (schema *ExtendedSchema) IsProperty() bool {
 }
 
 func (schema *ExtendedSchema) IsSelfReference() bool {
-	parentLocations := schema.getParentLocations()
+	parentLocations := schema.getParentEntryLocations()
 	for _, parentLocation := range parentLocations {
 		if parentLocation == schema.Location {
 			return true
@@ -95,11 +95,11 @@ func (schema *ExtendedSchema) IsSelfReference() bool {
 	return false
 }
 
-func (schema *ExtendedSchema) getParentLocations() []string {
+func (schema *ExtendedSchema) getParentEntryLocations() []string {
 	locations := []string{}
 	if schema.Parent != nil {
 		locations = append(locations, schema.Parent.Location)
-		locations = append(locations, schema.Parent.getParentLocations()...)
+		locations = append(locations, schema.Parent.getParentEntryLocations()...)
 	}
 	return locations
 }
@@ -109,4 +109,12 @@ func (schema *ExtendedSchema) GetReferenceLevel() int {
 		return 0
 	}
 	return schema.Parent.GetReferenceLevel() + 1
+}
+
+func GetParentPropertyPath(conciseLocation string) string {
+	path := strings.Split(conciseLocation, "/")
+	if len(path) <= 1 {
+		return ""
+	}
+	return strings.Join(path[:len(path)-1], "/")
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds three new rules for titles in cluster-app validation as defined in R4 in this [RFC](https://github.com/giantswarm/rfc/pull/55): 

- The title MUST NOT contain punctuation marks, leading or trailing white space, control characters, tabs, nor multiple whitespaces in a row.
- The title MUST be written using sentence case capitalization.
- If the title annotates a property that is part of another object, the title SHOULD NOT include the parent property name, to avoid repetition.

### What is the effect of this change to users?

Users that run the `verify` command with the `--rule-set` cluster-app flag will see additional recommendations and errors.

### How does it look like?
```
❯ go run ./main.go verify ./pkg/lint/rules/testdata/title_all_rules_fail.json --skip-normalization --rule-set cluster-app

Recommendations (3)

...
- Property '/cluster/name' title must not contain parent title 'Cluster'.

Errors (3)

- Property '/cluster/name' title must not contain illegal characters: ["\n" "\t" "."]
- Property '/cluster/name' title must not contain leading or trailing spaces
- Property '/cluster/name' title must start with a capital letter.

Verification result

- [SUCCESS] Input is valid JSON Schema.
- [ERROR] Input is not valid according to rule set 'cluster-app'.

exit status 1

```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1772
[RFC](https://github.com/giantswarm/rfc/pull/55)

### What is needed from the reviewers?

You can test the changes with:
```
go run ./main.go verify ./pkg/lint/rules/testdata/title_all_rules_fail.json --skip-normalization --rule-set cluster-app
```

Currently, we test for sentence case by only looking at whether the first letter is capitalized. Of course, this does not capture a string like `"Cluster Name"`, which is not in sentence case. If you know a method to reliably generate a sentence case string, let me know.  

### Do the docs/README need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
