### PR TITLE
Add check that arrays define a schema for their items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
+- Add check that every array specifies the schema of its items with the `items` keyword.
 - Add check that `additionalProperties` is disabled on all objects.
 
 ## [0.6.0] - 2023-02-02

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/fatih/color v1.13.0
 	github.com/google/go-cmp v0.5.9
-	github.com/santhosh-tekuri/jsonschema/v5 v5.1.1
+	github.com/santhosh-tekuri/jsonschema/v5 v5.2.0
 	github.com/spf13/cobra v1.6.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/santhosh-tekuri/jsonschema/v5 v5.1.1 h1:lEOLY2vyGIqKWUI9nzsOJRV3mb3WC9dXYORsLEUcoeY=
-github.com/santhosh-tekuri/jsonschema/v5 v5.1.1/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
+github.com/santhosh-tekuri/jsonschema/v5 v5.2.0 h1:WCcC4vZDS1tYNxjWlwRJZQy28r8CMoggKnxNzxsVDMQ=
+github.com/santhosh-tekuri/jsonschema/v5 v5.2.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/pkg/lint/rules/arrays_must_have_items_schema.go
+++ b/pkg/lint/rules/arrays_must_have_items_schema.go
@@ -1,0 +1,33 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type ArraysMustHaveItems struct{}
+
+func (r ArraysMustHaveItems) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+
+	callback := func(schema *schemautils.ExtendedSchema) {
+		if !hasItems(schema) {
+			ruleResults.Add(fmt.Sprintf("Array '%s' must specify the schema of its items.", schema.GetHumanReadableLocation()))
+		}
+	}
+
+	utils.RecurseArrays(schema, callback)
+
+	return *ruleResults
+}
+
+func hasItems(schema *schemautils.ExtendedSchema) bool {
+	return schema.Items2020 != nil || schema.Items != nil
+}
+
+func (r ArraysMustHaveItems) GetSeverity() lint.Severity {
+	return lint.SeverityError
+}

--- a/pkg/lint/rules/arrays_must_have_items_schema_test.go
+++ b/pkg/lint/rules/arrays_must_have_items_schema_test.go
@@ -1,0 +1,47 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+func TestArraysMustHaveItems(t *testing.T) {
+	testCases := []struct {
+		name        string
+		schemaPath  string
+		nViolations int
+		rules       []lint.Rule
+	}{
+		{
+			name:        "array without items",
+			schemaPath:  "testdata/arrays_must_have_items/without_items.json",
+			nViolations: 1,
+			rules:       []lint.Rule{ArraysMustHaveItems{}},
+		},
+		{
+			name:        "array with items",
+			schemaPath:  "testdata/arrays_must_have_items/with_items.json",
+			nViolations: 0,
+			rules:       []lint.Rule{ArraysMustHaveItems{}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+
+			ruleResults := []string{}
+			for _, rule := range tc.rules {
+				ruleResults = append(ruleResults, rule.Verify(schema).Violations...)
+			}
+
+			if len(ruleResults) != tc.nViolations {
+				t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleResults))
+			}
+		})
+	}
+}

--- a/pkg/lint/rules/testdata/additional_properties/disabled.json
+++ b/pkg/lint/rules/testdata/additional_properties/disabled.json
@@ -1,12 +1,13 @@
 {
-  "type": "object",
-  "properties": {
-    "name": {
-      "type": "string"
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "additionalProperties": false,
+    "properties": {
+        "age": {
+            "type": "integer"
+        },
+        "name": {
+            "type": "string"
+        }
     },
-    "age": {
-      "type": "integer"
-    }
-  },
-  "additionalProperties": false
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/arrays_must_have_items/with_items.json
+++ b/pkg/lint/rules/testdata/arrays_must_have_items/with_items.json
@@ -1,11 +1,11 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "properties": {
-        "age": {
-            "type": "integer"
-        },
-        "name": {
-            "type": "string"
+        "foo": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
         }
     },
     "type": "object"

--- a/pkg/lint/rules/testdata/arrays_must_have_items/without_items.json
+++ b/pkg/lint/rules/testdata/arrays_must_have_items/without_items.json
@@ -1,11 +1,8 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
     "properties": {
-        "age": {
-            "type": "integer"
-        },
-        "name": {
-            "type": "string"
+        "foo": {
+            "type": "array"
         }
     },
     "type": "object"

--- a/pkg/lint/rules/testdata/description_correct/8_missing_descriptions.json
+++ b/pkg/lint/rules/testdata/description_correct/8_missing_descriptions.json
@@ -1,5 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "properties": {
         "addresses": {
             "items": {

--- a/pkg/lint/rules/testdata/description_correct/description_all_rules_fail.json
+++ b/pkg/lint/rules/testdata/description_correct/description_all_rules_fail.json
@@ -1,5 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "properties": {
         "lastName": {
             "description": "c Cluster name\n",

--- a/pkg/lint/rules/testdata/description_correct/description_contains_title.json
+++ b/pkg/lint/rules/testdata/description_correct/description_contains_title.json
@@ -1,11 +1,12 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "lastName": {
-      "description": "Cluster name identifies the cluster uniquely within the installation.",
-      "title": "Cluster name",
-      "type": "string"
-    }
-  },
-  "type": "object"
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "lastName": {
+            "description": "Cluster name identifies the cluster uniquely within the installation.",
+            "title": "Cluster name",
+            "type": "string"
+        }
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/description_correct/description_correct.json
+++ b/pkg/lint/rules/testdata/description_correct/description_correct.json
@@ -1,11 +1,12 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "lastName": {
-      "description": "Identifies the cluster uniquely within the installation.",
-      "title": "Cluster name",
-      "type": "string"
-    }
-  },
-  "type": "object"
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "lastName": {
+            "description": "Identifies the cluster uniquely within the installation.",
+            "title": "Cluster name",
+            "type": "string"
+        }
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/description_correct/description_no_punctuation.json
+++ b/pkg/lint/rules/testdata/description_correct/description_no_punctuation.json
@@ -1,11 +1,12 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "lastName": {
-      "description": "Identifies the cluster uniquely within the installation",
-      "title": "Cluster name",
-      "type": "string"
-    }
-  },
-  "type": "object"
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "lastName": {
+            "description": "Identifies the cluster uniquely within the installation",
+            "title": "Cluster name",
+            "type": "string"
+        }
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/description_correct/description_not_sentence_case.json
+++ b/pkg/lint/rules/testdata/description_correct/description_not_sentence_case.json
@@ -1,11 +1,12 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "lastName": {
-      "description": "identifies the cluster uniquely within the installation.",
-      "title": "Cluster name",
-      "type": "string"
-    }
-  },
-  "type": "object"
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "lastName": {
+            "description": "identifies the cluster uniquely within the installation.",
+            "title": "Cluster name",
+            "type": "string"
+        }
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/description_correct/description_too_long.json
+++ b/pkg/lint/rules/testdata/description_correct/description_too_long.json
@@ -1,11 +1,12 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "lastName": {
-      "description": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-      "title": "Cluster name",
-      "type": "string"
-    }
-  },
-  "type": "object"
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "lastName": {
+            "description": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+            "title": "Cluster name",
+            "type": "string"
+        }
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/description_correct/description_too_short.json
+++ b/pkg/lint/rules/testdata/description_correct/description_too_short.json
@@ -1,11 +1,12 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "lastName": {
-      "description": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
-      "title": "Cluster name",
-      "type": "string"
-    }
-  },
-  "type": "object"
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "lastName": {
+            "description": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+            "title": "Cluster name",
+            "type": "string"
+        }
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/description_correct/description_with_illegal_chars.json
+++ b/pkg/lint/rules/testdata/description_correct/description_with_illegal_chars.json
@@ -1,36 +1,37 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "lastName": {
-      "description": "Identifies the cluster uniquely within the installation.\n",
-      "title": "Cluster name",
-      "type": "string"
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "fifthName": {
+            "description": "Identifies the cluster uniquely within the installation. ",
+            "title": "First name",
+            "type": "string"
+        },
+        "firstName": {
+            "description": "Identifies the cluster uniquely within the installation.\r",
+            "title": "First name",
+            "type": "string"
+        },
+        "fourthName": {
+            "description": "Identifies the cluster uniquely   within the installation.",
+            "title": "First name",
+            "type": "string"
+        },
+        "lastName": {
+            "description": "Identifies the cluster uniquely within the installation.\n",
+            "title": "Cluster name",
+            "type": "string"
+        },
+        "sixthName": {
+            "description": " Identifies the cluster uniquely within the installation. ",
+            "title": "First name",
+            "type": "string"
+        },
+        "thirdName": {
+            "description": "Identifies the cluster uniquely\t within the installation.",
+            "title": "First name",
+            "type": "string"
+        }
     },
-    "firstName": {
-      "description": "Identifies the cluster uniquely within the installation.\r",
-      "title": "First name",
-      "type": "string"
-    },
-    "thirdName": {
-      "description": "Identifies the cluster uniquely\t within the installation.",
-      "title": "First name",
-      "type": "string"
-    },
-    "fourthName": {
-      "description": "Identifies the cluster uniquely   within the installation.",
-      "title": "First name",
-      "type": "string"
-    },
-    "fifthName": {
-      "description": "Identifies the cluster uniquely within the installation. ",
-      "title": "First name",
-      "type": "string"
-    },
-    "sixthName": {
-      "description": " Identifies the cluster uniquely within the installation. ",
-      "title": "First name",
-      "type": "string"
-    }
-  },
-  "type": "object"
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/description_exists/8_missing_descriptions.json
+++ b/pkg/lint/rules/testdata/description_exists/8_missing_descriptions.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "properties": {
         "addresses": {
             "items": {

--- a/pkg/lint/rules/testdata/description_exists/has_descriptions.json
+++ b/pkg/lint/rules/testdata/description_exists/has_descriptions.json
@@ -1,5 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "properties": {
         "addresses": {
             "description": "The person's addresses.",

--- a/pkg/lint/rules/testdata/title_all_rules_fail.json
+++ b/pkg/lint/rules/testdata/title_all_rules_fail.json
@@ -1,16 +1,17 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "cluster": {
-      "title": "Cluster",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "title": " cluster name\n\t."
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "cluster": {
+            "properties": {
+                "name": {
+                    "title": " cluster name\n\t.",
+                    "type": "string"
+                }
+            },
+            "title": "Cluster",
+            "type": "object"
         }
-      }
-    }
-  },
-  "type": "object"
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/title_contains_parents_title.json
+++ b/pkg/lint/rules/testdata/title_contains_parents_title.json
@@ -1,15 +1,16 @@
 {
-  "properties": {
-    "controlPlane": {
-      "properties": {
-        "availabilityZones": {
-          "type": "string",
-          "title": "Control Plane Availability Zones"
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "controlPlane": {
+            "properties": {
+                "availabilityZones": {
+                    "title": "Control Plane Availability Zones",
+                    "type": "string"
+                }
+            },
+            "title": "Control Plane",
+            "type": "object"
         }
-      },
-      "title": "Control Plane",
-      "type": "object"
-    }
-  },
-  "type": "object"
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/title_correct.json
+++ b/pkg/lint/rules/testdata/title_correct.json
@@ -1,16 +1,17 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "cluster": {
-      "title": "Cluster",
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "title": "Name"
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "cluster": {
+            "properties": {
+                "name": {
+                    "title": "Name",
+                    "type": "string"
+                }
+            },
+            "title": "Cluster",
+            "type": "object"
         }
-      }
-    }
-  },
-  "type": "object"
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/title_exists/8_missing_titles.json
+++ b/pkg/lint/rules/testdata/title_exists/8_missing_titles.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "properties": {
         "addresses": {
             "description": "The person's addresses.",

--- a/pkg/lint/rules/testdata/title_exists/9_missing_titles_referenced.json
+++ b/pkg/lint/rules/testdata/title_exists/9_missing_titles_referenced.json
@@ -1,8 +1,9 @@
 {
-  "properties": {
-    "person": {
-      "$ref": "8_missing_titles.json"
-    }
-  },
-  "type": "object"
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "person": {
+            "$ref": "8_missing_titles.json"
+        }
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/title_exists/9_missing_titles_referenced_overridden.json
+++ b/pkg/lint/rules/testdata/title_exists/9_missing_titles_referenced_overridden.json
@@ -1,49 +1,50 @@
 {
-  "properties": {
-    "person": {
-      "title": "Person",
-      "$ref": "8_missing_titles.json",
-      "properties": {
-        "addresses": {
-          "title": "Addresses",
-          "items": {
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "person": {
+            "$ref": "8_missing_titles.json",
             "properties": {
-              "city": {
-                "title": "City",
-                "type": "string"
-              },
-              "state": {
-                "title": "State",
-                "type": "string"
-              },
-              "street": {
-                "title": "Street",
-                "type": "string"
-              },
-              "zip": {
-                "title": "Zip",
-                "type": "string"
-              }
+                "addresses": {
+                    "items": {
+                        "properties": {
+                            "city": {
+                                "title": "City",
+                                "type": "string"
+                            },
+                            "state": {
+                                "title": "State",
+                                "type": "string"
+                            },
+                            "street": {
+                                "title": "Street",
+                                "type": "string"
+                            },
+                            "zip": {
+                                "title": "Zip",
+                                "type": "string"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "title": "Addresses",
+                    "type": "array"
+                },
+                "age": {
+                    "title": "Age",
+                    "type": "integer"
+                },
+                "firstName": {
+                    "title": "First Name",
+                    "type": "string"
+                },
+                "lastName": {
+                    "title": "Last Name",
+                    "type": "string"
+                }
             },
+            "title": "Person",
             "type": "object"
-          },
-          "type": "array"
-        },
-        "age": {
-          "title": "Age",
-          "type": "integer"
-        },
-        "firstName": {
-          "title": "First Name",
-          "type": "string"
-        },
-        "lastName": {
-          "title": "Last Name",
-          "type": "string"
         }
-      },
-      "type": "object"
-    }
-  },
-  "type": "object"
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/title_exists/has_titles.json
+++ b/pkg/lint/rules/testdata/title_exists/has_titles.json
@@ -1,5 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
     "properties": {
         "addresses": {
             "description": "The person's addresses.",

--- a/pkg/lint/rules/testdata/title_not_sentence_case.json
+++ b/pkg/lint/rules/testdata/title_not_sentence_case.json
@@ -1,10 +1,11 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "lastName": {
-      "title": "cluster name",
-      "type": "string"
-    }
-  },
-  "type": "object"
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "lastName": {
+            "title": "cluster name",
+            "type": "string"
+        }
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/title_with_illegal_chars.json
+++ b/pkg/lint/rules/testdata/title_with_illegal_chars.json
@@ -1,46 +1,47 @@
 {
-  "$id": "https://example.com/person.schema.json",
-  "properties": {
-    "firstName": {
-      "title": "First name!",
-      "type": "string"
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "eighthName": {
+            "title": "First name\t",
+            "type": "string"
+        },
+        "fifthName": {
+            "title": "First name ",
+            "type": "string"
+        },
+        "firstName": {
+            "title": "First name!",
+            "type": "string"
+        },
+        "fourthName": {
+            "title": "First name,",
+            "type": "string"
+        },
+        "ninthName": {
+            "title": "First  name",
+            "type": "string"
+        },
+        "secondName": {
+            "title": "Cluster name.",
+            "type": "string"
+        },
+        "seventhName": {
+            "title": "First name\n",
+            "type": "string"
+        },
+        "sixthName": {
+            "title": " First name",
+            "type": "string"
+        },
+        "tenthName": {
+            "title": "First name\r",
+            "type": "string"
+        },
+        "thirdName": {
+            "title": "First name?",
+            "type": "string"
+        }
     },
-    "secondName": {
-      "title": "Cluster name.",
-      "type": "string"
-    },
-    "thirdName": {
-      "title": "First name?",
-      "type": "string"
-    },
-    "fourthName": {
-      "title": "First name,",
-      "type": "string"
-    },
-    "fifthName": {
-      "title": "First name ",
-      "type": "string"
-    },
-    "sixthName": {
-      "title": " First name",
-      "type": "string"
-    },
-    "seventhName": {
-      "title": "First name\n",
-      "type": "string"
-    },
-    "eighthName": {
-      "title": "First name\t",
-      "type": "string"
-    },
-    "ninthName": {
-      "title": "First  name",
-      "type": "string"
-    },
-    "tenthName": {
-      "title": "First name\r",
-      "type": "string"
-    }
-  },
-  "type": "object"
+    "type": "object"
 }

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -31,6 +31,7 @@ var ClusterApp = &RuleSet{
 		rules.DescriptionShouldHaveCorrectLength{},
 		rules.MustUseCorrectDialect{},
 		rules.ShouldDisableAdditionalProperties{},
+		rules.ArraysMustHaveItems{},
 	},
 }
 

--- a/pkg/lint/utils/recurse.go
+++ b/pkg/lint/utils/recurse.go
@@ -44,11 +44,21 @@ func RecurseProperties(schema *schemautils.ExtendedSchema, callback func(schema 
 }
 
 func RecurseObjects(schema *schemautils.ExtendedSchema, callback func(schema *schemautils.ExtendedSchema)) {
-	callbackIfProperty := func(schema *schemautils.ExtendedSchema) {
+	callbackIfObject := func(schema *schemautils.ExtendedSchema) {
 		if schema.IsObject() {
 			callback(schema)
 		}
 	}
 
-	RecurseAll(schema, callbackIfProperty)
+	RecurseAll(schema, callbackIfObject)
+}
+
+func RecurseArrays(schema *schemautils.ExtendedSchema, callback func(schema *schemautils.ExtendedSchema)) {
+	callbackIfArray := func(schema *schemautils.ExtendedSchema) {
+		if schema.IsArray() {
+			callback(schema)
+		}
+	}
+
+	RecurseAll(schema, callbackIfArray)
 }

--- a/pkg/lint/utils/recurse.go
+++ b/pkg/lint/utils/recurse.go
@@ -23,6 +23,14 @@ func RecurseAll(schema *schemautils.ExtendedSchema, callback func(schema *schema
 	if schema.Items2020 != nil {
 		RecurseAll(schema.GetItems2020(), callback)
 	}
+
+	if schema.Items != nil {
+		schemas := schema.GetItems()
+		for _, itemSchema := range schemas {
+			RecurseAll(itemSchema, callback)
+		}
+	}
+
 }
 
 func RecurseProperties(schema *schemautils.ExtendedSchema, callback func(schema *schemautils.ExtendedSchema)) {

--- a/pkg/schemautils/schemautils.go
+++ b/pkg/schemautils/schemautils.go
@@ -59,6 +59,29 @@ func (schema *ExtendedSchema) GetItems2020() *ExtendedSchema {
 	return newSchema
 }
 
+func (schema *ExtendedSchema) GetItems() []*ExtendedSchema {
+	if schema.Items == nil {
+		return nil
+	}
+
+	schemas := []*jsonschema.Schema{}
+	switch schema.Items.(type) {
+	case *jsonschema.Schema:
+		schemas = append(schemas, schema.Items.(*jsonschema.Schema))
+	case []*jsonschema.Schema:
+		schemas = append(schemas, schema.Items.([]*jsonschema.Schema)...)
+	}
+
+	extendedSchemas := make([]*ExtendedSchema, len(schemas))
+	for i, item := range schemas {
+		newSchema := NewExtendedSchema(item)
+		newSchema.InheritParentFrom(schema)
+		extendedSchemas[i] = newSchema
+	}
+
+	return extendedSchemas
+}
+
 // Gets current location without '/properties' in path
 // e.g. /properties/cluster/properties/azure/properties/credentialSecret/properties/namespace
 // becomes /cluster/azure/credentialSecret/namespace

--- a/pkg/schemautils/schemautils.go
+++ b/pkg/schemautils/schemautils.go
@@ -119,13 +119,21 @@ func (schema *ExtendedSchema) IsProperty() bool {
 }
 
 func (schema *ExtendedSchema) IsObject() bool {
-	isObject := false
+	return schema.isType("object")
+}
+
+func (schema *ExtendedSchema) IsArray() bool {
+	return schema.isType("array")
+}
+
+func (schema *ExtendedSchema) isType(typeName string) bool {
+	isType := false
 	for _, t := range schema.Types {
-		if t == "object" {
-			isObject = true
+		if t == typeName {
+			isType = true
 		}
 	}
-	return isObject
+	return isType
 }
 
 func (schema *ExtendedSchema) IsSelfReference() bool {


### PR DESCRIPTION
### What does this PR do?

This PR adds a new rule to check whether all arrays define a schema for their items with the `items` keyword as defined in R3 in this [RFC](https://github.com/giantswarm/rfc/pull/55).

Additionally, I've modified the test data JSON files to use the correct draft version, which also required some changes on the recursion functions.

### What is the effect of this change to users?

Users that run the `verify` command with the `--rule-set` cluster-app flag will see additional errors.

### How does it look like?

```
❯ go run ./main.go verify ./pkg/lint/rules/testdata/arrays_must_have_items/without_items.json --rule-set cluster-app

Recommendations (2)

...

Errors (2)

- Array '/foo' must specify the schema of its items.
...

Verification result

- [SUCCESS] Input is valid JSON Schema.
- [SUCCESS] Input is normalized.
- [ERROR] Input is not valid according to rule set 'cluster-app'.

```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1772
[RFC](https://github.com/giantswarm/rfc/pull/55)

### What is needed from the reviewers?

You can test the changes with:
```
go run ./main.go verify ./pkg/lint/rules/testdata/arrays_must_have_items/without_items.json --rule-set cluster-app
```

### Do the docs/README need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
