### PR TITLE
Remove `-` in front of error from output for GitHub actions log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
+- Simplify output of `schemalint verify` to improve appearance in GitHub actions log.
 - Add check that `additionalProperties` is disabled on all objects.
 
 ## [0.6.0] - 2023-02-02

--- a/cmd/verify/output.go
+++ b/cmd/verify/output.go
@@ -50,9 +50,9 @@ func printSummary(results []TestResult) {
 	var summary string
 	for _, r := range results {
 		if r.Success {
-			summary += "- " + cli.SprintSuccessMessage(r.Message) + "\n"
+			summary += cli.SprintSuccessMessage(r.Message) + "\n"
 		} else {
-			summary += "- " + cli.SprintErrorMessage(r.Message) + "\n"
+			summary += cli.SprintErrorMessage(r.Message) + "\n"
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR removes the leading `-` from the output of the `verify` command, because it causes malformed output in GitHub actions.

### What is the effect of this change to users?

Users of `schemalint verify` inside of GitHub actions will have a more appealing output.

### How does it look like?
Before:
```
- [ERROR] Input is not valid according to rule set 'cluster-app'.
```

After:
```
[ERROR] Input is not valid according to rule set 'cluster-app'.
```

### Any background context you can provide?

The issue was first observed in https://github.com/giantswarm/cluster-azure/pull/37#issuecomment-1415088534

### What is needed from the reviewers?

An approval ;)

### Do the docs/README need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
