### PR TITLE
Add rule to check whether deprecated properties have comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add check that every deprecated property has a comment.
 - Add check that every array specifies the schema of its items with the `items` keyword.
 - Simplify output of `schemalint verify` to improve appearance in GitHub actions log.
 - Add check that `additionalProperties` is disabled on all objects.

--- a/pkg/lint/rules/deprecated_properties_should_have_comment.go
+++ b/pkg/lint/rules/deprecated_properties_should_have_comment.go
@@ -1,0 +1,28 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type DeprecatedPropertiesShouldHaveComment struct{}
+
+func (r DeprecatedPropertiesShouldHaveComment) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+	callback := func(schema *schemautils.ExtendedSchema) {
+		if schema.Deprecated && schema.Comment == "" {
+			ruleResults.Add(fmt.Sprintf("Deprecated property '%s' should have a comment.", schema.GetHumanReadableLocation()))
+		}
+	}
+
+	utils.RecurseProperties(schema, callback)
+
+	return *ruleResults
+}
+
+func (r DeprecatedPropertiesShouldHaveComment) GetSeverity() lint.Severity {
+	return lint.SeverityError
+}

--- a/pkg/lint/rules/deprecated_properties_should_have_comment.go
+++ b/pkg/lint/rules/deprecated_properties_should_have_comment.go
@@ -24,5 +24,5 @@ func (r DeprecatedPropertiesShouldHaveComment) Verify(schema *schemautils.Extend
 }
 
 func (r DeprecatedPropertiesShouldHaveComment) GetSeverity() lint.Severity {
-	return lint.SeverityError
+	return lint.SeverityRecommendation
 }

--- a/pkg/lint/rules/deprecated_properties_should_have_comment.go
+++ b/pkg/lint/rules/deprecated_properties_should_have_comment.go
@@ -14,7 +14,7 @@ func (r DeprecatedPropertiesShouldHaveComment) Verify(schema *schemautils.Extend
 	ruleResults := &lint.RuleResults{}
 	callback := func(schema *schemautils.ExtendedSchema) {
 		if schema.Deprecated && schema.Comment == "" {
-			ruleResults.Add(fmt.Sprintf("Deprecated property '%s' should have a comment.", schema.GetHumanReadableLocation()))
+			ruleResults.Add(fmt.Sprintf("Deprecated property '%s' should have a $comment.", schema.GetHumanReadableLocation()))
 		}
 	}
 

--- a/pkg/lint/rules/deprecated_properties_should_have_comment_test.go
+++ b/pkg/lint/rules/deprecated_properties_should_have_comment_test.go
@@ -1,0 +1,46 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+func TestDeprecatedPropertiesShouldHaveComment(t *testing.T) {
+	testCases := []struct {
+		name        string
+		schemaPath  string
+		nViolations int
+	}{
+		{
+			name:        "no deprecated properties",
+			schemaPath:  "testdata/deprecated_properties/no_deprecated_properties.json",
+			nViolations: 0,
+		},
+		{
+			name:        "deprecated properties without comment",
+			schemaPath:  "testdata/deprecated_properties/deprecated_properties_without_comment.json",
+			nViolations: 1,
+		},
+		{
+			name:        "deprecated properties with comment",
+			schemaPath:  "testdata/deprecated_properties/deprecated_properties_with_comment.json",
+			nViolations: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+			rule := DeprecatedPropertiesShouldHaveComment{}
+			ruleResults := rule.Verify(schema)
+
+			if len(ruleResults.Violations) != tc.nViolations {
+				t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleResults.Violations))
+			}
+		})
+	}
+}

--- a/pkg/lint/rules/testdata/deprecated_properties/deprecated_properties_with_comment.json
+++ b/pkg/lint/rules/testdata/deprecated_properties/deprecated_properties_with_comment.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "foo": {
+            "$comment": "Use bar instead",
+            "deprecated": true,
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/deprecated_properties/deprecated_properties_without_comment.json
+++ b/pkg/lint/rules/testdata/deprecated_properties/deprecated_properties_without_comment.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "foo": {
+            "deprecated": true,
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/deprecated_properties/no_deprecated_properties.json
+++ b/pkg/lint/rules/testdata/deprecated_properties/no_deprecated_properties.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "foo": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -32,6 +32,7 @@ var ClusterApp = &RuleSet{
 		rules.MustUseCorrectDialect{},
 		rules.ShouldDisableAdditionalProperties{},
 		rules.ArraysMustHaveItems{},
+		rules.DeprecatedPropertiesShouldHaveComment{},
 	},
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a new rule to check whether all properties provide one or more examples through the `examples` keyword as defined in R10 in this [RFC](https://github.com/giantswarm/rfc/pull/55).

### What is the effect of this change to users?

Users that run the `verify` command with the `--rule-set` cluster-app flag will see additional recommendations.

### How does it look like?

```
❯ go run ./main.go verify --rule-set cluster-app ./pkg/lint/rules/testdata/deprecated_properties/deprecated_properties_without_comment.json
...
- Deprecated property '/foo' should have a comment.
...
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1772
[RFC](https://github.com/giantswarm/rfc/pull/55)

### What is needed from the reviewers?

You can test the changes with:
```
go run ./main.go verify --rule-set cluster-app ./pkg/lint/rules/testdata/deprecated_properties/deprecated_properties_without_comment.json
```

### Do the docs/README need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
