### PR TITLE
Add check that properties don't provide too many examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add check that properties don't provide more than 5 examples.
+
 ## [0.7.0] - 2023-02-06
 
 - Add check that every array specifies the schema of its items with the `items` keyword.

--- a/pkg/lint/rules/examples_should_not_be_too_many.go
+++ b/pkg/lint/rules/examples_should_not_be_too_many.go
@@ -1,0 +1,31 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type ExamplesShouldNotBeTooMany struct{}
+
+const maxExamples = 5
+
+func (r ExamplesShouldNotBeTooMany) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+
+	propertyAnnotationsMap := utils.BuildPropertyAnnotationsMap(schema)
+	for path, propertyAnnotations := range propertyAnnotationsMap {
+		examples := propertyAnnotations.GetExamples()
+		if len(examples) > maxExamples {
+			ruleResults.Add(fmt.Sprintf("Property '%s' should not have more than %d examples.", path, maxExamples))
+		}
+	}
+
+	return *ruleResults
+}
+
+func (r ExamplesShouldNotBeTooMany) GetSeverity() lint.Severity {
+	return lint.SeverityRecommendation
+}

--- a/pkg/lint/rules/examples_should_not_be_too_many_test.go
+++ b/pkg/lint/rules/examples_should_not_be_too_many_test.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+func TestExamplesShouldNotBeTooMany(t *testing.T) {
+	testCases := []struct {
+		name        string
+		schemaPath  string
+		nViolations int
+	}{
+		{
+			name:        "too many examples",
+			schemaPath:  "testdata/examples_correct/too_many_examples.json",
+			nViolations: 1,
+		},
+		{
+			name:        "correct number of examples",
+			schemaPath:  "testdata/examples_correct/correct.json",
+			nViolations: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+			titleExistsRule := ExamplesShouldNotBeTooMany{}
+			ruleResults := titleExistsRule.Verify(schema)
+
+			if len(ruleResults.Violations) != tc.nViolations {
+				t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleResults.Violations))
+			}
+		})
+	}
+}

--- a/pkg/lint/rules/testdata/examples_correct/correct.json
+++ b/pkg/lint/rules/testdata/examples_correct/correct.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "name": {
+            "examples": [
+                "Jane Doe",
+                "John Smith",
+                "Jane Smith",
+                "John Doe-Smith",
+                "Jane Doe-Smith"
+            ],
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/examples_correct/too_many_examples.json
+++ b/pkg/lint/rules/testdata/examples_correct/too_many_examples.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "properties": {
+        "name": {
+            "examples": [
+                "John Doe",
+                "Jane Doe",
+                "John Smith",
+                "Jane Smith",
+                "John Doe-Smith",
+                "Jane Doe-Smith"
+            ],
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -32,6 +32,7 @@ var ClusterApp = &RuleSet{
 		rules.MustUseCorrectDialect{},
 		rules.ShouldDisableAdditionalProperties{},
 		rules.ArraysMustHaveItems{},
+		rules.ExamplesShouldNotBeTooMany{},
 	},
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a new rule to check whether the schema does not provide too many examples (no more than five) as defined in R6 in this [RFC](https://github.com/giantswarm/rfc/pull/55).

### What is the effect of this change to users?

Users that run the `verify` command with the `--rule-set` cluster-app flag will see additional recommendations.

### How does it look like?

```
Recommendations (3)

- Property '/name' should not have more than 5 examples.
...
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1772
[RFC](https://github.com/giantswarm/rfc/pull/55)

### What is needed from the reviewers?

You can test the changes with:
```
go run ./main.go verify --rule-set cluster-app ./pkg/lint/rules/testdata/examples_correct/too_many_examples.json
```

### Do the docs/README need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
