### PR TITLE
Update draft/dialect to 2020

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Change required draft back to 2020-12.
 - Add check that every numeric property is constrained through 'minimum', 'maximum', 'exclusiveMinimum' or 'exclusiveMaximum'.
 - Add check that every string property is constrained through 'pattern', 'minLength', 'maxLength', 'enum', 'constant' or 'format'.
 - Add check that every property provides one or more examples with the `examples` keyword.
@@ -60,7 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added first basic linting.
 
-[Unreleased]: https://github.com/giantswarm/schemalint/compare/v0.7.0...HEAD
+[unreleased]: https://github.com/giantswarm/schemalint/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/giantswarm/schemalint/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/giantswarm/schemalint/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/giantswarm/schemalint/compare/v0.4.0...v0.5.0

--- a/pkg/lint/rules/must_use_correct_dialect.go
+++ b/pkg/lint/rules/must_use_correct_dialect.go
@@ -11,7 +11,7 @@ import (
 
 type MustUseCorrectDialect struct{}
 
-const correctDraft = "https://json-schema.org/draft/2019-09/schema"
+const correctDraft = "https://json-schema.org/draft/2020-12/schema"
 const draftKey = "$schema"
 
 func (r MustUseCorrectDialect) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {

--- a/pkg/lint/rules/testdata/additional_properties/disabled.json
+++ b/pkg/lint/rules/testdata/additional_properties/disabled.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "additionalProperties": false,
     "properties": {
         "age": {

--- a/pkg/lint/rules/testdata/additional_properties/not_disabled.json
+++ b/pkg/lint/rules/testdata/additional_properties/not_disabled.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "age": {
             "type": "integer"

--- a/pkg/lint/rules/testdata/arrays_must_have_items/with_items.json
+++ b/pkg/lint/rules/testdata/arrays_must_have_items/with_items.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "foo": {
             "items": {

--- a/pkg/lint/rules/testdata/arrays_must_have_items/without_items.json
+++ b/pkg/lint/rules/testdata/arrays_must_have_items/without_items.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "foo": {
             "type": "array"

--- a/pkg/lint/rules/testdata/deprecated_properties/deprecated_properties_with_comment.json
+++ b/pkg/lint/rules/testdata/deprecated_properties/deprecated_properties_with_comment.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "foo": {
             "$comment": "Use bar instead",

--- a/pkg/lint/rules/testdata/deprecated_properties/deprecated_properties_without_comment.json
+++ b/pkg/lint/rules/testdata/deprecated_properties/deprecated_properties_without_comment.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "foo": {
             "deprecated": true,

--- a/pkg/lint/rules/testdata/deprecated_properties/no_deprecated_properties.json
+++ b/pkg/lint/rules/testdata/deprecated_properties/no_deprecated_properties.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "foo": {
             "items": {

--- a/pkg/lint/rules/testdata/description_correct/8_missing_descriptions.json
+++ b/pkg/lint/rules/testdata/description_correct/8_missing_descriptions.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "addresses": {
             "items": {

--- a/pkg/lint/rules/testdata/description_correct/description_all_rules_fail.json
+++ b/pkg/lint/rules/testdata/description_correct/description_all_rules_fail.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "lastName": {
             "description": "c Cluster name\n",

--- a/pkg/lint/rules/testdata/description_correct/description_contains_title.json
+++ b/pkg/lint/rules/testdata/description_correct/description_contains_title.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "lastName": {
             "description": "Cluster name identifies the cluster uniquely within the installation.",

--- a/pkg/lint/rules/testdata/description_correct/description_correct.json
+++ b/pkg/lint/rules/testdata/description_correct/description_correct.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "lastName": {
             "description": "Identifies the cluster uniquely within the installation.",

--- a/pkg/lint/rules/testdata/description_correct/description_no_punctuation.json
+++ b/pkg/lint/rules/testdata/description_correct/description_no_punctuation.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "lastName": {
             "description": "Identifies the cluster uniquely within the installation",

--- a/pkg/lint/rules/testdata/description_correct/description_not_sentence_case.json
+++ b/pkg/lint/rules/testdata/description_correct/description_not_sentence_case.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "lastName": {
             "description": "identifies the cluster uniquely within the installation.",

--- a/pkg/lint/rules/testdata/description_correct/description_too_long.json
+++ b/pkg/lint/rules/testdata/description_correct/description_too_long.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "lastName": {
             "description": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",

--- a/pkg/lint/rules/testdata/description_correct/description_too_short.json
+++ b/pkg/lint/rules/testdata/description_correct/description_too_short.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "lastName": {
             "description": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",

--- a/pkg/lint/rules/testdata/description_correct/description_with_illegal_chars.json
+++ b/pkg/lint/rules/testdata/description_correct/description_with_illegal_chars.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "fifthName": {
             "description": "Identifies the cluster uniquely within the installation. ",

--- a/pkg/lint/rules/testdata/description_exists/8_missing_descriptions.json
+++ b/pkg/lint/rules/testdata/description_exists/8_missing_descriptions.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "addresses": {
             "items": {

--- a/pkg/lint/rules/testdata/description_exists/has_descriptions.json
+++ b/pkg/lint/rules/testdata/description_exists/has_descriptions.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "addresses": {
             "description": "The person's addresses.",

--- a/pkg/lint/rules/testdata/dialect/correct_dialect.json
+++ b/pkg/lint/rules/testdata/dialect/correct_dialect.json
@@ -1,3 +1,3 @@
 {
-  "$schema": "https://json-schema.org/draft/2019-09/schema"
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
 }

--- a/pkg/lint/rules/testdata/dialect/incorrect_dialect.json
+++ b/pkg/lint/rules/testdata/dialect/incorrect_dialect.json
@@ -1,3 +1,3 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema"
+    "$schema": "https://json-schema.org/draft/2019-09/schema"
 }

--- a/pkg/lint/rules/testdata/examples_correct/correct.json
+++ b/pkg/lint/rules/testdata/examples_correct/correct.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "name": {
             "examples": [

--- a/pkg/lint/rules/testdata/examples_correct/too_many_examples.json
+++ b/pkg/lint/rules/testdata/examples_correct/too_many_examples.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "name": {
             "examples": [

--- a/pkg/lint/rules/testdata/examples_exist/has_examples.json
+++ b/pkg/lint/rules/testdata/examples_exist/has_examples.json
@@ -1,5 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "foo": {
             "examples": [

--- a/pkg/lint/rules/testdata/examples_exist/no_examples.json
+++ b/pkg/lint/rules/testdata/examples_exist/no_examples.json
@@ -1,5 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "foo": {
             "type": "string"

--- a/pkg/lint/rules/testdata/numbers_should_be_constrained/correct.json
+++ b/pkg/lint/rules/testdata/numbers_should_be_constrained/correct.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "foo1": {
             "minimum": 0,

--- a/pkg/lint/rules/testdata/numbers_should_be_constrained/unconstrained_number.json
+++ b/pkg/lint/rules/testdata/numbers_should_be_constrained/unconstrained_number.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "foo1": {
             "type": "number"

--- a/pkg/lint/rules/testdata/strings_should_be_constrained/correct.json
+++ b/pkg/lint/rules/testdata/strings_should_be_constrained/correct.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "foo1": {
             "minLength": 1,

--- a/pkg/lint/rules/testdata/strings_should_be_constrained/unconstrained_string.json
+++ b/pkg/lint/rules/testdata/strings_should_be_constrained/unconstrained_string.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "name": {
             "type": "string"

--- a/pkg/lint/rules/testdata/title_correct/title_all_rules_fail.json
+++ b/pkg/lint/rules/testdata/title_correct/title_all_rules_fail.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "cluster": {
             "properties": {

--- a/pkg/lint/rules/testdata/title_correct/title_contains_parents_title.json
+++ b/pkg/lint/rules/testdata/title_correct/title_contains_parents_title.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "controlPlane": {
             "properties": {

--- a/pkg/lint/rules/testdata/title_correct/title_correct.json
+++ b/pkg/lint/rules/testdata/title_correct/title_correct.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "cluster": {
             "properties": {

--- a/pkg/lint/rules/testdata/title_correct/title_not_sentence_case.json
+++ b/pkg/lint/rules/testdata/title_correct/title_not_sentence_case.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "lastName": {
             "title": "cluster name",

--- a/pkg/lint/rules/testdata/title_correct/title_with_illegal_chars.json
+++ b/pkg/lint/rules/testdata/title_correct/title_with_illegal_chars.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "eighthName": {
             "title": "First name\t",

--- a/pkg/lint/rules/testdata/title_exists/8_missing_titles.json
+++ b/pkg/lint/rules/testdata/title_exists/8_missing_titles.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "addresses": {
             "description": "The person's addresses.",

--- a/pkg/lint/rules/testdata/title_exists/9_missing_titles_referenced.json
+++ b/pkg/lint/rules/testdata/title_exists/9_missing_titles_referenced.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "person": {
             "$ref": "8_missing_titles.json"

--- a/pkg/lint/rules/testdata/title_exists/9_missing_titles_referenced_overridden.json
+++ b/pkg/lint/rules/testdata/title_exists/9_missing_titles_referenced_overridden.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "person": {
             "$ref": "8_missing_titles.json",

--- a/pkg/lint/rules/testdata/title_exists/has_titles.json
+++ b/pkg/lint/rules/testdata/title_exists/has_titles.json
@@ -1,6 +1,6 @@
 {
     "$id": "https://example.com/person.schema.json",
-    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "properties": {
         "addresses": {
             "description": "The person's addresses.",


### PR DESCRIPTION
### What does this PR do?

This PR changes the required draft back to 2020. 

### What is the effect of this change to users?

Users that use the `--rule-set cluster-app` have to use the draft 2020-12.

### How does it look like?

Nothing has changed visually. 

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1772
[RFC](https://github.com/giantswarm/rfc/pull/55)
### What is needed from the reviewers?

### Do the docs/README need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
