### PR TITLE
Add rule to check whether properties have exactly one type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add rule to check whether all properties have exactly one type.
 - Change required draft back to 2020-12.
 - Add check that every numeric property is constrained through 'minimum', 'maximum', 'exclusiveMinimum' or 'exclusiveMaximum'.
 - Add check that every string property is constrained through 'pattern', 'minLength', 'maxLength', 'enum', 'constant' or 'format'.

--- a/pkg/lint/rules/properties_must_have_one_type.go
+++ b/pkg/lint/rules/properties_must_have_one_type.go
@@ -1,0 +1,31 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type PropertiesMustHaveOneType struct{}
+
+func (r PropertiesMustHaveOneType) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+
+	callback := func(schema *schemautils.ExtendedSchema) {
+		if len(schema.Types) > 1 {
+			ruleResults.Add(fmt.Sprintf("Property '%s' has %d types, but must have exactly one.", schema.GetHumanReadableLocation(), len(schema.Types)))
+		}
+		if len(schema.Types) == 0 && schema.Ref == nil {
+			ruleResults.Add(fmt.Sprintf("Property '%s' must have exactly one type unless '$ref' is used.", schema.GetHumanReadableLocation()))
+		}
+	}
+
+	utils.RecurseProperties(schema, callback)
+	return *ruleResults
+}
+
+func (r PropertiesMustHaveOneType) GetSeverity() lint.Severity {
+	return lint.SeverityError
+}

--- a/pkg/lint/rules/properties_must_have_one_type_test.go
+++ b/pkg/lint/rules/properties_must_have_one_type_test.go
@@ -1,0 +1,51 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+func TestPropertiesMustHaveOneType(t *testing.T) {
+	testCases := []struct {
+		name        string
+		schemaPath  string
+		nViolations int
+	}{
+		{
+			name:        "property with multiple types",
+			schemaPath:  "testdata/properties_must_have_one_type/multiple_types.json",
+			nViolations: 1,
+		},
+		{
+			name:        "property with no types",
+			schemaPath:  "testdata/properties_must_have_one_type/no_type.json",
+			nViolations: 1,
+		},
+		{
+			name:        "property with one type",
+			schemaPath:  "testdata/properties_must_have_one_type/one_type.json",
+			nViolations: 0,
+		},
+		{
+			name:        "property with no type but ref",
+			schemaPath:  "testdata/properties_must_have_one_type/no_type_reference.json",
+			nViolations: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+			exampleExistsRule := PropertiesMustHaveOneType{}
+			ruleResults := exampleExistsRule.Verify(schema)
+
+			if len(ruleResults.Violations) != tc.nViolations {
+				t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleResults.Violations))
+			}
+		})
+	}
+}

--- a/pkg/lint/rules/testdata/properties_must_have_one_type/multiple_types.json
+++ b/pkg/lint/rules/testdata/properties_must_have_one_type/multiple_types.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "replicas": {
+            "type": ["integer", "string"]
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/properties_must_have_one_type/no_type.json
+++ b/pkg/lint/rules/testdata/properties_must_have_one_type/no_type.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "replicas": {}
+    },
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/properties_must_have_one_type/no_type_reference.json
+++ b/pkg/lint/rules/testdata/properties_must_have_one_type/no_type_reference.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "replicas": {
+            "$ref": "one_type.json"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/properties_must_have_one_type/one_type.json
+++ b/pkg/lint/rules/testdata/properties_must_have_one_type/one_type.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "replicas": {
+            "type": "integer"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -37,6 +37,7 @@ var ClusterApp = &RuleSet{
 		rules.ExampleExists{},
 		rules.DeprecatedPropertiesShouldHaveComment{},
 		rules.ExamplesShouldNotBeTooMany{},
+		rules.PropertiesMustHaveOneType{},
 	},
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a new rule to check all properties have exactly one type as defined by R2 in this [RFC](https://github.com/giantswarm/rfc/pull/55).

### What is the effect of this change to users?

Users that run the `verify` command with the `--rule-set` cluster-app flag will see additional errors.

### How does it look like?

```
Errors (3)

- Property '/replicas' has 2 types, but must have exactly one.
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1772
[RFC](https://github.com/giantswarm/rfc/pull/55)

### What is needed from the reviewers?

You can test the changes with:
```
go run ./main.go verify ./pkg/lint/rules/testdata/properties_must_have_one_type/multiple_types.json --rule-set=cluster-app
```

### Do the docs/README need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
