### PR TITLE
Don't require examples for boolean properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Don't require examples for boolean properties.
 - Change required draft back to 2020-12.
 - Add check that every numeric property is constrained through 'minimum', 'maximum', 'exclusiveMinimum' or 'exclusiveMaximum'.
 - Add check that every string property is constrained through 'pattern', 'minLength', 'maxLength', 'enum', 'constant' or 'format'.

--- a/pkg/lint/rules/examples_exist_test.go
+++ b/pkg/lint/rules/examples_exist_test.go
@@ -22,6 +22,11 @@ func TestExampleExists(t *testing.T) {
 			schemaPath:  "testdata/examples_exist/has_examples.json",
 			nViolations: 0,
 		},
+		{
+			name:        "no examples, but boolean",
+			schemaPath:  "testdata/examples_exist/no_examples_but_boolean.json",
+			nViolations: 0,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/lint/rules/examples_exists.go
+++ b/pkg/lint/rules/examples_exists.go
@@ -13,12 +13,22 @@ type ExampleExists struct{}
 func (r ExampleExists) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
 	ruleResults := &lint.RuleResults{}
 	propertyAnnotationsMap := utils.BuildPropertyAnnotationsMap(schema)
-	for path, annotations := range propertyAnnotationsMap {
-		if len(annotations.GetExamples()) == 0 {
-			ruleResults.Add(fmt.Sprintf("Property '%s' should provide one or more examples.", path))
+	for location, annotations := range propertyAnnotationsMap {
+		if len(annotations.GetExamples()) == 0 && !annotationBelongsToBoolean(schema, location) {
+			ruleResults.Add(fmt.Sprintf("Property '%s' should provide one or more examples.", location))
 		}
 	}
 	return *ruleResults
+}
+
+func annotationBelongsToBoolean(schema *schemautils.ExtendedSchema, location string) bool {
+	schemas := schema.GetSchemasAt(location)
+	for _, s := range schemas {
+		if s.IsBoolean() {
+			return true
+		}
+	}
+	return false
 }
 
 func (r ExampleExists) GetSeverity() lint.Severity {

--- a/pkg/lint/rules/testdata/examples_exist/no_examples_but_boolean.json
+++ b/pkg/lint/rules/testdata/examples_exist/no_examples_but_boolean.json
@@ -1,0 +1,10 @@
+{
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "foo": {
+            "type": "boolean"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/schemautils/schemautils_test.go
+++ b/pkg/schemautils/schemautils_test.go
@@ -1,0 +1,54 @@
+package schemautils_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+func TestGetSchemasAt(t *testing.T) {
+	tests := []struct {
+		name           string
+		schemaPath     string
+		location       string
+		expectedTitles []string
+	}{
+		{
+			name:           "simple",
+			schemaPath:     "testdata/simple.json",
+			location:       "/rootProp",
+			expectedTitles: []string{"gold"},
+		},
+		{
+			name:           "nested",
+			schemaPath:     "testdata/nested.json",
+			location:       "/rootProp/childProp/grandchildProp",
+			expectedTitles: []string{"gold"},
+		},
+		{
+			name:           "referenced",
+			schemaPath:     "testdata/referenced.json",
+			location:       "/rootProp/childProp/grandchildProp",
+			expectedTitles: []string{"gold", "gold_ref", "gold_ref_ref"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+			foundSchemas := schema.GetSchemasAt(tc.location)
+			foundTitles := []string{}
+			for _, foundSchema := range foundSchemas {
+				foundTitles = append(foundTitles, foundSchema.Title)
+			}
+			if !cmp.Equal(foundTitles, tc.expectedTitles) {
+				t.Fatalf("Unexpected schemas found in test case '%s':\n%s", tc.name, cmp.Diff(foundTitles, tc.expectedTitles))
+			}
+		})
+	}
+}

--- a/pkg/schemautils/testdata/nested.json
+++ b/pkg/schemautils/testdata/nested.json
@@ -1,0 +1,19 @@
+{
+    "properties": {
+        "rootProp": {
+            "properties": {
+                "childProp": {
+                    "type": "object",
+                    "properties": {
+                        "grandchildProp": {
+                            "type": "string",
+                            "title": "gold"
+                        }
+                    }
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/schemautils/testdata/referenced.json
+++ b/pkg/schemautils/testdata/referenced.json
@@ -1,0 +1,45 @@
+{
+    "$defs": {
+        "foo": {
+            "properties": {
+                "childProp": {
+                    "type": "object",
+                    "$ref": "#/$defs/bar",
+                    "properties": {
+                        "grandchildProp": {
+                            "type": "string",
+                            "title": "gold_ref"
+                        }
+                    }
+                }
+            },
+            "type": "object"
+        },
+        "bar": {
+            "properties": {
+                "grandchildProp": {
+                    "type": "string",
+                    "title": "gold_ref_ref"
+                }
+            }
+        }
+    },
+    "properties": {
+        "rootProp": {
+            "$ref": "#/$defs/foo",
+            "properties": {
+                "childProp": {
+                    "type": "object",
+                    "properties": {
+                        "grandchildProp": {
+                            "type": "string",
+                            "title": "gold"
+                        }
+                    }
+                }
+            },
+            "type": "object"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/schemautils/testdata/simple.json
+++ b/pkg/schemautils/testdata/simple.json
@@ -1,0 +1,9 @@
+{
+    "properties": {
+        "rootProp": {
+            "type": "string",
+            "title": "gold"
+        }
+    },
+    "type": "object"
+}


### PR DESCRIPTION
### What does this PR do?

This PR modifies the existing rule "properties should have examples" to ignore boolean properties without examples.
This change is more complex than it initially seems because the type that is associated with a given value of an example (or any annotation) is ambiguous. When using `$ref` to reference an external schema, users are able to add keywords besides `$ref`, which lets them override the annotations from the referenced schema. 
This implementation checks the type of all type that is associated with the annotation value. If any is of type boolean, then the rule ignores that annotation.

### What is the effect of this change to users?

Users that run the `verify` command with the `--rule-set` cluster-app flag won't see the recommendation to add examples to their boolean properties.

### How does it look like?

The output of the rule looks the same as before.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1772
[RFC](https://github.com/giantswarm/rfc/pull/55)

### What is needed from the reviewers?

You can test the changes with by comparing the output of the following two commands:
```
go run ./main.go verify ./pkg/lint/rules/testdata/examples_exist/no_examples.json --rule-set=cluster-app
go run ./main.go verify ./pkg/lint/rules/testdata/examples_exist/no_examples_but_boolean.json --rule-set=cluster-app
```

### Do the docs/README need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
