### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added first basic linting.
 
-[unreleased]: https://github.com/giantswarm/schemalint/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/giantswarm/schemalint/compare/v0.7.0...HEAD
 [0.7.0]: https://github.com/giantswarm/schemalint/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/giantswarm/schemalint/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/giantswarm/schemalint/compare/v0.4.0...v0.5.0


### PR DESCRIPTION
### What does this PR do?

In one of the unreleased PRs I accidentally formatted `CHANGELOG.md` with my formatted, which turns
```markdown
[Unreleased]: https://github.com/giantswarm/schemalint/compare/v0.7.0...HEAD
```
into
```markdown
[unreleased]: https://github.com/giantswarm/schemalint/compare/v0.7.0...HEAD
```

This prevents the release actions to run correctly.