### PR TITLE
Add rule to enforce single type array items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add rule to check whether logical constructs (if, then & else) are not used.
 - Add check that schemas only use `anyOf` and `oneOf` for specific purposes.
+- Add rule to check that arrays only specify one type for their items.
 
 ## [0.8.0] - 2023-02-24
 

--- a/pkg/lint/rules/array_items_must_have_single_type.go
+++ b/pkg/lint/rules/array_items_must_have_single_type.go
@@ -1,0 +1,44 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type ArrayItemsMustHaveSingleType struct{}
+
+func (r ArrayItemsMustHaveSingleType) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+
+	callback := func(schema *schemautils.ExtendedSchema) {
+		if containedKeywords := getContainedIllegalArrayKeywords(schema); len(containedKeywords) != 0 {
+			ruleResults.Add(fmt.Sprintf("Array at '%s' must not use keyword(s): %s.", schema.GetHumanReadableLocation(), strings.Join(containedKeywords, ", ")))
+		}
+	}
+
+	utils.RecurseArrays(schema, callback)
+
+	return *ruleResults
+}
+
+func getContainedIllegalArrayKeywords(schema *schemautils.ExtendedSchema) []string {
+	containedKeywords := []string{}
+	if schema.AdditionalItems != nil {
+		containedKeywords = append(containedKeywords, "additionalItems")
+	}
+	if schema.Contains != nil {
+		containedKeywords = append(containedKeywords, "contains")
+	}
+	if schema.PrefixItems != nil {
+		containedKeywords = append(containedKeywords, "prefixItems")
+	}
+	return containedKeywords
+}
+
+func (r ArrayItemsMustHaveSingleType) GetSeverity() lint.Severity {
+	return lint.SeverityError
+}

--- a/pkg/lint/rules/array_items_must_have_single_type_test.go
+++ b/pkg/lint/rules/array_items_must_have_single_type_test.go
@@ -1,0 +1,59 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+func TestArrayItemsMustHaveSingleType(t *testing.T) {
+	testCases := []struct {
+		name        string
+		schemaPath  string
+		nViolations int
+		rules       []lint.Rule
+	}{
+		{
+			name:        "case 0: array with 'contains'",
+			schemaPath:  "testdata/array_items_must_have_single_type/contains.json",
+			nViolations: 1,
+			rules:       []lint.Rule{ArrayItemsMustHaveSingleType{}},
+		},
+		{
+			name:        "case 1: array with 'prefixItems'",
+			schemaPath:  "testdata/array_items_must_have_single_type/prefix_items.json",
+			nViolations: 1,
+			rules:       []lint.Rule{ArrayItemsMustHaveSingleType{}},
+		},
+		{
+			name:        "case 1: array with 'prefixItems' and 'contains'",
+			schemaPath:  "testdata/array_items_must_have_single_type/multiple_illegal_keywords.json",
+			nViolations: 1,
+			rules:       []lint.Rule{ArrayItemsMustHaveSingleType{}},
+		},
+		{
+			name:        "case 2: correct array",
+			schemaPath:  "testdata/array_items_must_have_single_type/correct.json",
+			nViolations: 0,
+			rules:       []lint.Rule{ArrayItemsMustHaveSingleType{}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+
+			ruleResults := []string{}
+			for _, rule := range tc.rules {
+				ruleResults = append(ruleResults, rule.Verify(schema).Violations...)
+			}
+
+			if len(ruleResults) != tc.nViolations {
+				t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleResults))
+			}
+		})
+	}
+}

--- a/pkg/lint/rules/testdata/array_items_must_have_single_type/contains.json
+++ b/pkg/lint/rules/testdata/array_items_must_have_single_type/contains.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "foo": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "contains": {
+        "const": "bar"
+      }
+    }
+  },
+  "type": "object"
+}

--- a/pkg/lint/rules/testdata/array_items_must_have_single_type/contains.json
+++ b/pkg/lint/rules/testdata/array_items_must_have_single_type/contains.json
@@ -1,15 +1,15 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "properties": {
-    "foo": {
-      "items": {
-        "type": "string"
-      },
-      "type": "array",
-      "contains": {
-        "const": "bar"
-      }
-    }
-  },
-  "type": "object"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "foo": {
+            "contains": {
+                "const": "bar"
+            },
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/array_items_must_have_single_type/correct.json
+++ b/pkg/lint/rules/testdata/array_items_must_have_single_type/correct.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "foo": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    }
+  },
+  "type": "object"
+}

--- a/pkg/lint/rules/testdata/array_items_must_have_single_type/correct.json
+++ b/pkg/lint/rules/testdata/array_items_must_have_single_type/correct.json
@@ -1,12 +1,12 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "properties": {
-    "foo": {
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    }
-  },
-  "type": "object"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "foo": {
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/array_items_must_have_single_type/multiple_illegal_keywords.json
+++ b/pkg/lint/rules/testdata/array_items_must_have_single_type/multiple_illegal_keywords.json
@@ -1,21 +1,21 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "properties": {
-    "foo": {
-      "items": {
-        "type": "string"
-      },
-      "type": "array",
-      "prefixItems": [
-        {
-          "type": "string",
-          "format": "date"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "foo": {
+            "contains": {
+                "const": "bar"
+            },
+            "items": {
+                "type": "string"
+            },
+            "prefixItems": [
+                {
+                    "format": "date",
+                    "type": "string"
+                }
+            ],
+            "type": "array"
         }
-      ],
-      "contains": {
-        "const": "bar"
-      }
-    }
-  },
-  "type": "object"
+    },
+    "type": "object"
 }

--- a/pkg/lint/rules/testdata/array_items_must_have_single_type/multiple_illegal_keywords.json
+++ b/pkg/lint/rules/testdata/array_items_must_have_single_type/multiple_illegal_keywords.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "foo": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "string",
+          "format": "date"
+        }
+      ],
+      "contains": {
+        "const": "bar"
+      }
+    }
+  },
+  "type": "object"
+}

--- a/pkg/lint/rules/testdata/array_items_must_have_single_type/prefix_items.json
+++ b/pkg/lint/rules/testdata/array_items_must_have_single_type/prefix_items.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "properties": {
+    "foo": {
+      "items": {
+        "type": "string"
+      },
+      "type": "array",
+      "prefixItems": [
+        {
+          "type": "string",
+          "format": "date"
+        }
+      ]
+    }
+  },
+  "type": "object"
+}

--- a/pkg/lint/rules/testdata/array_items_must_have_single_type/prefix_items.json
+++ b/pkg/lint/rules/testdata/array_items_must_have_single_type/prefix_items.json
@@ -1,18 +1,18 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "properties": {
-    "foo": {
-      "items": {
-        "type": "string"
-      },
-      "type": "array",
-      "prefixItems": [
-        {
-          "type": "string",
-          "format": "date"
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "foo": {
+            "items": {
+                "type": "string"
+            },
+            "prefixItems": [
+                {
+                    "format": "date",
+                    "type": "string"
+                }
+            ],
+            "type": "array"
         }
-      ]
-    }
-  },
-  "type": "object"
+    },
+    "type": "object"
 }

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -41,6 +41,7 @@ var ClusterApp = &RuleSet{
 		rules.AvoidUnevaluated{},
 		rules.PropertiesMustHaveOneType{},
 		rules.AvoidLogicalConstruct{},
+		rules.ArrayItemsMustHaveSingleType{},
 	},
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a new rule to check that the items of arrays only have one type as defined by R16 in this [RFC](https://github.com/giantswarm/rfc/pull/55). 
As a single type is already enforced by another rule, we only check for keywords, that would allow multiple types per array: `additionalItems`, `prefixItems` and `contains`.

### What is the effect of this change to users?

Users that run the `verify` command with the `--rule-set` cluster-app flag will see additional errors.

### How does it look like?

```
Errors (1)

- Array at '/foo' must not use keyword(s): contains, prefixItems.
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1772
[RFC](https://github.com/giantswarm/rfc/pull/55)

### What is needed from the reviewers?

You can test the changes with:
```
go run ./main.go verify ./pkg/lint/rules/testdata/array_items_must_have_single_type/multiple_illegal_keywords.json --rule-set=cluster-app
```

### Do the docs/README need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
