### PR TITLE
Avoid recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add rules to forbid infinite recursion and recursion-related keywords.
 - Add rule to check whether logical constructs (if, then & else) are not used.
 - Add check that schemas only use `anyOf` and `oneOf` for specific purposes.
 

--- a/pkg/lint/rules/avoid_recursion.go
+++ b/pkg/lint/rules/avoid_recursion.go
@@ -1,0 +1,26 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type AvoidRecursion struct{}
+
+func (r AvoidRecursion) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+
+	utils.RecurseAllPre(schema, func(schema *schemautils.ExtendedSchema) {
+		if schema.IsSelfReference() {
+			ruleResults.Add(fmt.Sprintf("Schema at '%s' must not reference itself.", schema.GetHumanReadableLocation()))
+		}
+	})
+	return *ruleResults
+}
+
+func (r AvoidRecursion) GetSeverity() lint.Severity {
+	return lint.SeverityError
+}

--- a/pkg/lint/rules/avoid_recursion_keywords.go
+++ b/pkg/lint/rules/avoid_recursion_keywords.go
@@ -1,0 +1,30 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type AvoidRecursionKeywords struct{}
+
+func (r AvoidRecursionKeywords) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+
+	utils.RecurseAll(schema, func(schema *schemautils.ExtendedSchema) {
+		if schema.DynamicAnchor != "" || schema.DynamicRef != nil || schema.RecursiveRef != nil {
+			ruleResults.Add(
+				fmt.Sprintf(
+					"Schema at '%s' must not use recursion keywords (dynamicAnchor, dynamicRef, recursiveRef).",
+					schema.GetHumanReadableLocation()),
+			)
+		}
+	})
+	return *ruleResults
+}
+
+func (r AvoidRecursionKeywords) GetSeverity() lint.Severity {
+	return lint.SeverityError
+}

--- a/pkg/lint/rules/avoid_recursion_keywords_test.go
+++ b/pkg/lint/rules/avoid_recursion_keywords_test.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+func TestAvoidRecursionKeywords(t *testing.T) {
+	testCases := []struct {
+		name        string
+		schemaPath  string
+		nViolations int
+	}{
+		{
+			name:        "case 0: contains dynamicRef",
+			schemaPath:  "testdata/avoid_recursion_keywords/dynamic_ref.json",
+			nViolations: 1,
+		},
+		{
+			name:        "case 1: correct",
+			schemaPath:  "testdata/avoid_recursion_keywords/correct.json",
+			nViolations: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+			titleExistsRule := AvoidRecursionKeywords{}
+			ruleResults := titleExistsRule.Verify(schema)
+
+			if len(ruleResults.Violations) != tc.nViolations {
+				t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleResults.Violations))
+			}
+		})
+	}
+}

--- a/pkg/lint/rules/avoid_recursion_test.go
+++ b/pkg/lint/rules/avoid_recursion_test.go
@@ -1,0 +1,41 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+func TestAvoidRecursion(t *testing.T) {
+	testCases := []struct {
+		name        string
+		schemaPath  string
+		nViolations int
+	}{
+		{
+			name:        "case 0: contains infinite recursion",
+			schemaPath:  "testdata/avoid_recursion/incorrect.json",
+			nViolations: 1,
+		},
+		{
+			name:        "case 1: correct",
+			schemaPath:  "testdata/avoid_recursion/correct.json",
+			nViolations: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+			titleExistsRule := AvoidRecursion{}
+			ruleResults := titleExistsRule.Verify(schema)
+
+			if len(ruleResults.Violations) != tc.nViolations {
+				t.Fatalf("Unexpected number of rule violations in test case '%s': Expected %d, got %d", tc.name, tc.nViolations, len(ruleResults.Violations))
+			}
+		})
+	}
+}

--- a/pkg/lint/rules/testdata/avoid_recursion/correct.json
+++ b/pkg/lint/rules/testdata/avoid_recursion/correct.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/avoid_recursion/incorrect.json
+++ b/pkg/lint/rules/testdata/avoid_recursion/incorrect.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "children": {
+            "items": {
+                "$ref": "#"
+            },
+            "type": "array"
+        },
+        "name": {
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/avoid_recursion_keywords/correct.json
+++ b/pkg/lint/rules/testdata/avoid_recursion_keywords/correct.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/avoid_recursion_keywords/dynamic_ref.json
+++ b/pkg/lint/rules/testdata/avoid_recursion_keywords/dynamic_ref.json
@@ -1,0 +1,10 @@
+{
+    "$defs": {
+        "string-items": {
+            "$dynamicAnchor": "T",
+            "type": "string"
+        }
+    },
+    "$ref": "list_of_t.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/pkg/lint/rules/testdata/avoid_recursion_keywords/list_of_t.json
+++ b/pkg/lint/rules/testdata/avoid_recursion_keywords/list_of_t.json
@@ -1,0 +1,14 @@
+{
+    "$defs": {
+        "content": {
+            "$dynamicAnchor": "T",
+            "not": true
+        }
+    },
+    "$id": "https://json-schema.blog/list-of-t",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "items": {
+        "$dynamicRef": "#T"
+    },
+    "type": "array"
+}

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -41,6 +41,8 @@ var ClusterApp = &RuleSet{
 		rules.AvoidUnevaluated{},
 		rules.PropertiesMustHaveOneType{},
 		rules.AvoidLogicalConstruct{},
+		rules.AvoidRecursion{},
+		rules.AvoidRecursionKeywords{},
 	},
 }
 

--- a/pkg/lint/utils/recurse.go
+++ b/pkg/lint/utils/recurse.go
@@ -11,23 +11,37 @@ func RecurseAll(schema *schemautils.ExtendedSchema, callback func(schema *schema
 
 	callback(schema)
 
+	CallChildren(schema, func(schema *schemautils.ExtendedSchema) {
+		RecurseAll(schema, callback)
+	})
+}
+
+func RecurseAllUnsafe(schema *schemautils.ExtendedSchema, callback func(schema *schemautils.ExtendedSchema)) {
+	callback(schema)
+
+	CallChildren(schema, func(schema *schemautils.ExtendedSchema) {
+		RecurseAllUnsafe(schema, callback)
+	})
+}
+
+func CallChildren(schema *schemautils.ExtendedSchema, callback func(schema *schemautils.ExtendedSchema)) {
 	if schema.Ref != nil {
 		refSchema := schema.GetRefSchema()
-		RecurseAll(refSchema, callback)
+		callback(refSchema)
 	}
 
 	for _, property := range schema.GetProperties() {
-		RecurseAll(property, callback)
+		callback(property)
 	}
 
 	if schema.Items2020 != nil {
-		RecurseAll(schema.GetItems2020(), callback)
+		callback(schema.GetItems2020())
 	}
 
 	if schema.Items != nil {
 		schemas := schema.GetItems()
 		for _, itemSchema := range schemas {
-			RecurseAll(itemSchema, callback)
+			callback(itemSchema)
 		}
 	}
 

--- a/pkg/lint/utils/recurse.go
+++ b/pkg/lint/utils/recurse.go
@@ -11,20 +11,24 @@ func RecurseAll(schema *schemautils.ExtendedSchema, callback func(schema *schema
 
 	callback(schema)
 
-	CallChildren(schema, func(schema *schemautils.ExtendedSchema) {
+	callChildren(schema, func(schema *schemautils.ExtendedSchema) {
 		RecurseAll(schema, callback)
 	})
 }
 
-func RecurseAllUnsafe(schema *schemautils.ExtendedSchema, callback func(schema *schemautils.ExtendedSchema)) {
+func RecurseAllPre(schema *schemautils.ExtendedSchema, callback func(schema *schemautils.ExtendedSchema)) {
 	callback(schema)
 
-	CallChildren(schema, func(schema *schemautils.ExtendedSchema) {
-		RecurseAllUnsafe(schema, callback)
+	if schema.IsSelfReference() {
+		return
+	}
+
+	callChildren(schema, func(schema *schemautils.ExtendedSchema) {
+		RecurseAllPre(schema, callback)
 	})
 }
 
-func CallChildren(schema *schemautils.ExtendedSchema, callback func(schema *schemautils.ExtendedSchema)) {
+func callChildren(schema *schemautils.ExtendedSchema, callback func(schema *schemautils.ExtendedSchema)) {
 	if schema.Ref != nil {
 		refSchema := schema.GetRefSchema()
 		callback(refSchema)


### PR DESCRIPTION
### What does this PR do?

This PR adds a new rule to check that the schema does not contain infinite recursion and recursion related keywords as defined by R13 in this [RFC](https://github.com/giantswarm/rfc/pull/55). 

### What is the effect of this change to users?

Users that run the `verify` command with the `--rule-set` cluster-app flag will see additional errors.

### How does it look like?

```
Errors (1)

- Schema at '/children/items/children/items' must not reference itself.

...

Errors (1)

- Schema at '/items' must not use recursion keywords (dynamicAnchor, dynamicRef, recursiveRef).
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1772
[RFC](https://github.com/giantswarm/rfc/pull/55)

### What is needed from the reviewers?

You can test the changes with:
```
go run ./main.go verify ./pkg/lint/rules/testdata/avoid_recursion_keywords/dynamic_ref.json --rule-set=cluster-app
```
```
go run ./main.go verify ./pkg/lint/rules/testdata/avoid_recursion/incorrect.json --rule-set=cluster-app
```

### Do the docs/README need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
