### PR TITLE
Add version command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add possibility to output version with `schemalint -v` or `schemalint --version`.
 - Add rule to check whether logical constructs (if, then & else) are not used.
 - Add check that schemas only use `anyOf` and `oneOf` for specific purposes.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/schemalint/cmd/normalize"
 	"github.com/giantswarm/schemalint/cmd/verify"
+	"github.com/giantswarm/schemalint/pkg/project"
 )
 
 var (
@@ -14,6 +15,7 @@ var (
 		Args:         cobra.MinimumNArgs(1),
 		ArgAliases:   []string{"PATH"},
 		SilenceUsage: true,
+		Version:      project.Version(),
 	}
 )
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,0 +1,9 @@
+package project
+
+var (
+	version = "0.8.0-dev"
+)
+
+func Version() string {
+	return version
+}


### PR DESCRIPTION
### What does this PR do?

This PR allows printing the current version of schemalint with `schemalint -v` and `schemalint --version`.

### What is the effect of this change to users?

Users can print the current version of schemalint with `schemalint -v` and `schemalint --version`.

### How does it look like?

```
❯ schemalint -v
schemalint version 0.8.0-dev
```

### Any background context you can provide?

Closes https://github.com/giantswarm/roadmap/issues/1862

### What is needed from the reviewers?

I added the `pkg/project/project.go` file. As much as I understand it should be automatically updated by Github actions.
Please tell me if I missed something.

### Do the docs/README need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
