### PR TITLE
Add composite GitHub action to be reused in external workflows

### DIFF
--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -1,3 +1,6 @@
+# This action runs when a release PR is opened and updates the version of 
+# schemalint in `actions/verify-helm-schema/action.yml` to the one of the PR.
+
 name: Update action yml
 on:
   pull_request:

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -1,0 +1,52 @@
+name: Update action yml
+on:
+  pull_request:
+    types: 
+      - opened
+
+jobs:
+  update_version:
+    name: Get version from PR title
+    runs-on: ubuntu-latest
+    outputs: 
+      version: ${{ steps.regex-match.outputs.group1 }}
+    steps:
+      - name: Run regex match action
+        uses: actions-ecosystem/action-regex-match@v2
+        id: regex-match
+        with:
+          text: ${{ github.event.pull_request.title }}
+          # (modified) official semver regix: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string 
+          regex: '^Release v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?)$'
+          flags: 'g'
+      - name: Check that the version is defined
+        run: |
+          if [ -z "${{ steps.regex-match.outputs.group1 }}" ]; then
+            echo "No version found"
+            exit 1
+          else
+            echo "Version found: ${{ steps.regex-match.outputs.group1 }}"
+          fi
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Update version in action.yml
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.runs.steps[0].with.version = "${{ steps.regex-match.outputs.group1 }}"' actions/verify-helm-schema/action.yml
+      - name: Set up git identity
+        run: |
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+      - name: Create release commit
+        run: |
+          git add -A
+          git commit -m "Update version in action.yml"
+      - name: Print current branch
+        run: |
+          echo "Current branch: $(git branch --show-current)"
+      - name: Push changes
+        env:
+          remote_repo: "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+        run: |
+          git push "${remote_repo}"
+

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -3,7 +3,7 @@ on:
   pull_request:
     types: 
       - opened
-
+      - reopened
 jobs:
   get_version:
     name: Get version from PR title

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -3,7 +3,6 @@ on:
   pull_request:
     types: 
       - opened
-      - reopened
 jobs:
   get_version:
     name: Get version from PR title

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -5,7 +5,7 @@ on:
       - opened
 
 jobs:
-  update_version:
+  get_version:
     name: Get version from PR title
     runs-on: ubuntu-latest
     outputs: 
@@ -23,16 +23,24 @@ jobs:
         run: |
           if [ -z "${{ steps.regex-match.outputs.group1 }}" ]; then
             echo "No version found"
-            exit 1
           else
             echo "Version found: ${{ steps.regex-match.outputs.group1 }}"
           fi
+
+  update_version:
+    name: Update version in action.yml
+    runs-on: ubuntu-latest
+    needs: get_version
+    if: needs.get_version.outputs.version 
+    steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
       - name: Update version in action.yml
         uses: mikefarah/yq@master
         with:
-          cmd: yq -i '.runs.steps[0].with.version = "${{ steps.regex-match.outputs.group1 }}"' actions/verify-helm-schema/action.yml
+          cmd: yq -i '.runs.steps[0].with.version = "${{ needs.get_version.outputs.version }}"' actions/verify-helm-schema/action.yml
       - name: Set up git identity
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -41,12 +49,9 @@ jobs:
         run: |
           git add -A
           git commit -m "Update version in action.yml"
-      - name: Print current branch
-        run: |
-          echo "Current branch: $(git branch --show-current)"
       - name: Push changes
         env:
           remote_repo: "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          branch_name: ${{ github.head_ref || github.ref_name }} 
         run: |
-          git push "${remote_repo}"
-
+          git push "${remote_repo}" "HEAD:${branch_name}"

--- a/.github/workflows/update_action.yaml
+++ b/.github/workflows/update_action.yaml
@@ -36,11 +36,11 @@ jobs:
     if: needs.get_version.outputs.version 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.head_ref || github.ref_name }}
       - name: Update version in action.yml
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@v4.31.2
         with:
           cmd: yq -i '.runs.steps[0].with.version = "${{ needs.get_version.outputs.version }}"' actions/verify-helm-schema/action.yml
       - name: Set up git identity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add a reusable composite GitHub action that calls `schemalint verify`. 
+
 ## [0.10.0] - 2023-03-07
 
 - Add possibility to exclude locations from rule set validation.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Run schemalint
         id: run-schemalint
-        uses: giantswarm/schemalint/actions/verify-helm-schema@v1.0.0
+        uses: giantswarm/schemalint/actions/verify-helm-schema@v1
         with:
           rule-set: 'cluster-app'
 ```
@@ -87,3 +87,14 @@ with:
   rule-set: 'RULE_SET'
 ```
 If the rule set is not specified, no rule set will be used.
+
+## Major Releases
+
+This repository uses [floating tags](https://github.com/giantswarm/floating-tags-action).
+Other repositories that use schemalint point to major floating tag versions,
+like `v1`. That means that all minor and patch releases will be automatically
+rolled out to these repositories.
+When doing a major release the following steps have to be completed:
+1. Create a new major floating tag under "Actions -> Ensure major version tags -> Run Workflow"
+2. Update all references to schemalint.
+    1. devctl: `pkg/gen/input/workflows/internal/file/cluster_app_schema_validation.yaml.template`

--- a/README.md
+++ b/README.md
@@ -54,3 +54,36 @@ $ schemalint normalize myschema.json > normalized.json
 ```
 
 Use `--help` to learn about more options.
+
+
+## GitHub Action
+
+An action to run `schemalint verify` on the `values.schema.json` in app repositories in provided in `actions/verify-helm-schema`.
+
+**Example workflow**:
+
+```yaml
+name: JSON schema validation
+on:
+  push: {}
+
+jobs:
+  validate:
+    name: Verify values.schema.json with schemalint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run schemalint
+        id: run-schemalint
+        uses: giantswarm/schemalint/actions/verify-helm-schema@v1.0.0
+        with:
+          rule-set: 'cluster-app'
+```
+
+Note that it is possible to define the rule set to be used for the `verify` command with the `with` keyword.
+```yaml
+with:
+  rule-set: 'RULE_SET'
+```
+If the rule set is not specified, no rule set will be used.

--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -6,16 +6,11 @@ inputs:
 runs: 
   using: composite
   steps:
-    - name: Checkout code
-      uses: actions/checkout@v3
-
-    - uses: actions/setup-go@v3
-      with:
-        go-version: "^1.19"
-
     - name: Install schemalint
-      shell: bash
-      run: go install github.com/giantswarm/schemalint@latest
+      uses: giantswarm/install-binary-action@v1.1.0
+      with:
+        binary: "schemalint"
+        version: "0.10.0"
 
     - name: Run schemalint
       shell: bash

--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -6,18 +6,11 @@ inputs:
 runs: 
   using: composite
   steps:
-    - id: get_version
-      uses: battila7/get-version-action@v2
     - name: Install schemalint
       uses: giantswarm/install-binary-action@v1.1.0
       with:
         binary: "schemalint"
-        version: ${{ steps.get_version.outputs.version-without-v }}
-
-    - run: echo ${{ steps.get_version.outputs.version }}
-      shell: bash
-    - run: echo ${{ steps.get_version.outputs.version-without-v }}
-      shell: bash
+        version: "0.10.0"
 
     - name: Run schemalint
       shell: bash

--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -21,4 +21,4 @@ runs:
 
     - name: Run schemalint
       shell: bash
-      run: ${{ github.action_path }}/verify-helm-schema.sh
+      run: ${{ github.action_path }}/verify-helm-schema.sh ${{ inputs.rule-set }}

--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -3,8 +3,6 @@ description: Verfies values.schema.json with schemalint verify and the specified
 inputs:
   rule-set:
     description: Rule set to use for verify command
-    required: true
-    default: ''
 runs: 
   using: composite
   steps:

--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -21,4 +21,4 @@ runs:
 
     - name: Run schemalint
       shell: bash
-      run: verify-helm-schema.sh
+      run: ${{ github.action_path }}/verify-helm-schema.sh

--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -6,11 +6,18 @@ inputs:
 runs: 
   using: composite
   steps:
+    - id: get_version
+      uses: battila7/get-version-action@v2
     - name: Install schemalint
       uses: giantswarm/install-binary-action@v1.1.0
       with:
         binary: "schemalint"
-        version: "0.10.0"
+        version: ${{ steps.get_version.outputs.version-without-v }}
+
+    - run: echo ${{ steps.get_version.outputs.version }}
+      shell: bash
+    - run: echo ${{ steps.get_version.outputs.version-without-v }}
+      shell: bash
 
     - name: Run schemalint
       shell: bash

--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -1,0 +1,24 @@
+name: Verify values.schema.json
+description: Verfies values.schema.json with schemalint verify and the specified rule set
+inputs:
+  rule-set:
+    description: Rule set to use for verify command
+    required: true
+    default: ''
+runs: 
+  using: composite
+  steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - uses: actions/setup-go@v3
+      with:
+        go-version: "^1.19"
+
+    - name: Install schemalint
+      shell: bash
+      run: go install github.com/giantswarm/schemalint@latest
+
+    - name: Run schemalint
+      shell: bash
+      run: verify-helm-schema.sh

--- a/actions/verify-helm-schema/verify-helm-schema.sh
+++ b/actions/verify-helm-schema/verify-helm-schema.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 RULE_SET"
+    exit 1
+fi
+
+RULE_SET=$1
+
+VALUES_SCHEMA=$(find ./helm -maxdepth 2 -name values.schema.json)
+
+schemalint verify ${VALUES_SCHEMA} --rule-set ${RULE_SET}

--- a/actions/verify-helm-schema/verify-helm-schema.sh
+++ b/actions/verify-helm-schema/verify-helm-schema.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
-if [ $# -ne 1 ]; then
-    echo "Usage: $0 RULE_SET"
-    exit 1
-fi
-
 RULE_SET=$1
 
 VALUES_SCHEMA=$(find ./helm -maxdepth 2 -name values.schema.json)
 
-schemalint verify ${VALUES_SCHEMA} --rule-set ${RULE_SET}
+echo "Running schemalint verify on ${VALUES_SCHEMA}"
+
+SCHEMALINT_ARGS=${VALUES_SCHEMA}
+
+if [ -z "$RULE_SET" ]; then
+    echo "Using no rule set"
+else
+    echo "Using rule set ${RULE_SET}"
+    SCHEMALINT_ARGS="${SCHEMALINT_ARGS} --rule-set ${RULE_SET}"
+fi
+
+schemalint verify ${SCHEMALINT_ARGS}


### PR DESCRIPTION
### What does this PR do?

This PR adds a [GitHub composite action](https://docs.github.com/en/actions/creating-actions/about-custom-actions#composite-actions) specifically for verifying the `values.schema.json` of apps (located in `./helm/<app>/values.schema.json`.
It is possible to provide the `rule-set` that should be used during verification as an input to the action.

### What is the effect of this change to users?

For CLI users of schemalint: none.
For workflow developers: It is now easy to create a workflow that validates the `values.schema.json` of a repository with a given rule set.

### How does it look like?

An example of how to use it can be found in the `README.md`.

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/2093
To improve https://github.com/giantswarm/devctl/pull/528

### Do the docs/README need to be updated?

`README.md` has been updated.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
