### PR TITLE
Fix module path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix module path.
+
 ## [1.0.0] - 2023-03-22
 
 - Fix update action workflow trigger.

--- a/cmd/normalize/output.go
+++ b/cmd/normalize/output.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/giantswarm/schemalint/v2/pkg/cli"
+	"github.com/giantswarm/schemalint/pkg/cli"
 )
 
 func handleOutput(output []byte, outputPath string) {

--- a/cmd/normalize/prerun.go
+++ b/cmd/normalize/prerun.go
@@ -3,7 +3,7 @@ package normalize
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/schemalint/v2/pkg/cli"
+	"github.com/giantswarm/schemalint/pkg/cli"
 )
 
 func (r *runner) preRun(cmd *cobra.Command, args []string) {

--- a/cmd/normalize/runner.go
+++ b/cmd/normalize/runner.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/schemalint/v2/pkg/cli"
-	"github.com/giantswarm/schemalint/v2/pkg/normalize"
+	"github.com/giantswarm/schemalint/pkg/cli"
+	"github.com/giantswarm/schemalint/pkg/normalize"
 )
 
 type runner struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/schemalint/v2/cmd/normalize"
-	"github.com/giantswarm/schemalint/v2/cmd/verify"
-	"github.com/giantswarm/schemalint/v2/pkg/project"
+	"github.com/giantswarm/schemalint/cmd/normalize"
+	"github.com/giantswarm/schemalint/cmd/verify"
+	"github.com/giantswarm/schemalint/pkg/project"
 )
 
 var (

--- a/cmd/verify/flag.go
+++ b/cmd/verify/flag.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/schemalint/v2/pkg/cli"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/rulesets"
+	"github.com/giantswarm/schemalint/pkg/cli"
+	"github.com/giantswarm/schemalint/pkg/lint/rulesets"
 )
 
 type flag struct {

--- a/cmd/verify/flag_test.go
+++ b/cmd/verify/flag_test.go
@@ -3,7 +3,7 @@ package verify
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint/rulesets"
+	"github.com/giantswarm/schemalint/pkg/lint/rulesets"
 )
 
 func TestValidateFlags(t *testing.T) {

--- a/cmd/verify/output.go
+++ b/cmd/verify/output.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/giantswarm/schemalint/v2/pkg/cli"
+	"github.com/giantswarm/schemalint/pkg/cli"
 )
 
 func printOutput(results []TestResult) {

--- a/cmd/verify/prerun.go
+++ b/cmd/verify/prerun.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/schemalint/v2/pkg/cli"
+	"github.com/giantswarm/schemalint/pkg/cli"
 )
 
 func (r *runner) preRun(cmd *cobra.Command, args []string) {

--- a/cmd/verify/runner.go
+++ b/cmd/verify/runner.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/rulesets"
-	"github.com/giantswarm/schemalint/v2/pkg/normalize"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/rulesets"
+	"github.com/giantswarm/schemalint/pkg/normalize"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type runner struct {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/schemalint/v2
+module github.com/giantswarm/schemalint
 
 go 1.19
 

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/giantswarm/schemalint/v2/cmd"
+	"github.com/giantswarm/schemalint/cmd"
 )
 
 func main() {

--- a/pkg/lint/lint.go
+++ b/pkg/lint/lint.go
@@ -8,7 +8,7 @@ import (
 	jsonschema "github.com/santhosh-tekuri/jsonschema/v5"
 	_ "github.com/santhosh-tekuri/jsonschema/v5/httploader"
 
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type draft struct {

--- a/pkg/lint/rules.go
+++ b/pkg/lint/rules.go
@@ -1,7 +1,7 @@
 package lint
 
 import (
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type Severity int

--- a/pkg/lint/rules/array_items_must_have_single_type.go
+++ b/pkg/lint/rules/array_items_must_have_single_type.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type ArrayItemsMustHaveSingleType struct{}

--- a/pkg/lint/rules/array_items_must_have_single_type_test.go
+++ b/pkg/lint/rules/array_items_must_have_single_type_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestArrayItemsMustHaveSingleType(t *testing.T) {

--- a/pkg/lint/rules/arrays_must_have_items_schema.go
+++ b/pkg/lint/rules/arrays_must_have_items_schema.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type ArraysMustHaveItems struct{}

--- a/pkg/lint/rules/arrays_must_have_items_schema_test.go
+++ b/pkg/lint/rules/arrays_must_have_items_schema_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestArraysMustHaveItems(t *testing.T) {

--- a/pkg/lint/rules/avoid_logical_construct.go
+++ b/pkg/lint/rules/avoid_logical_construct.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type AvoidLogicalConstruct struct{}

--- a/pkg/lint/rules/avoid_logical_constructs_test.go
+++ b/pkg/lint/rules/avoid_logical_constructs_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestAvoidLogicalContructs(t *testing.T) {

--- a/pkg/lint/rules/avoid_recursion.go
+++ b/pkg/lint/rules/avoid_recursion.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type AvoidRecursion struct{}

--- a/pkg/lint/rules/avoid_recursion_keywords.go
+++ b/pkg/lint/rules/avoid_recursion_keywords.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type AvoidRecursionKeywords struct{}

--- a/pkg/lint/rules/avoid_recursion_keywords_test.go
+++ b/pkg/lint/rules/avoid_recursion_keywords_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestAvoidRecursionKeywords(t *testing.T) {

--- a/pkg/lint/rules/avoid_recursion_test.go
+++ b/pkg/lint/rules/avoid_recursion_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestAvoidRecursion(t *testing.T) {

--- a/pkg/lint/rules/avoid_unevaluated.go
+++ b/pkg/lint/rules/avoid_unevaluated.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type AvoidUnevaluated struct{}

--- a/pkg/lint/rules/avoid_unevaluated_test.go
+++ b/pkg/lint/rules/avoid_unevaluated_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestAvoidUnevaluated(t *testing.T) {

--- a/pkg/lint/rules/avoid_x_of.go
+++ b/pkg/lint/rules/avoid_x_of.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type AvoidXOf struct{}

--- a/pkg/lint/rules/avoid_x_of_test.go
+++ b/pkg/lint/rules/avoid_x_of_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestShouldAvoidXOf(t *testing.T) {

--- a/pkg/lint/rules/deprecated_properties_should_have_comment.go
+++ b/pkg/lint/rules/deprecated_properties_should_have_comment.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type DeprecatedPropertiesShouldHaveComment struct{}

--- a/pkg/lint/rules/deprecated_properties_should_have_comment_test.go
+++ b/pkg/lint/rules/deprecated_properties_should_have_comment_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestDeprecatedPropertiesShouldHaveComment(t *testing.T) {

--- a/pkg/lint/rules/description_correct_test.go
+++ b/pkg/lint/rules/description_correct_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestDescriptionCorrect(t *testing.T) {

--- a/pkg/lint/rules/description_exists.go
+++ b/pkg/lint/rules/description_exists.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type DescriptionExists struct{}

--- a/pkg/lint/rules/description_exists_test.go
+++ b/pkg/lint/rules/description_exists_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestDescriptionExists(t *testing.T) {

--- a/pkg/lint/rules/description_must_be_sentence_case.go
+++ b/pkg/lint/rules/description_must_be_sentence_case.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type DescriptionMustBeSentenceCase struct{}

--- a/pkg/lint/rules/description_must_not_contain_illegal_characters.go
+++ b/pkg/lint/rules/description_must_not_contain_illegal_characters.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type DescriptionMustNotContainIllegalCharacters struct{}

--- a/pkg/lint/rules/description_must_use_punctuation.go
+++ b/pkg/lint/rules/description_must_use_punctuation.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 const AllowedEndings = ".!?"

--- a/pkg/lint/rules/description_should_have_correct_length.go
+++ b/pkg/lint/rules/description_should_have_correct_length.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 const maxDescriptionLength = 200

--- a/pkg/lint/rules/description_should_not_contain_title.go
+++ b/pkg/lint/rules/description_should_not_contain_title.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type DescriptionShouldNotContainTitle struct{}

--- a/pkg/lint/rules/examples_exist_test.go
+++ b/pkg/lint/rules/examples_exist_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestExampleExists(t *testing.T) {

--- a/pkg/lint/rules/examples_exists.go
+++ b/pkg/lint/rules/examples_exists.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type ExampleExists struct{}

--- a/pkg/lint/rules/examples_should_not_be_too_many.go
+++ b/pkg/lint/rules/examples_should_not_be_too_many.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type ExamplesShouldNotBeTooMany struct{}

--- a/pkg/lint/rules/examples_should_not_be_too_many_test.go
+++ b/pkg/lint/rules/examples_should_not_be_too_many_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestExamplesShouldNotBeTooMany(t *testing.T) {

--- a/pkg/lint/rules/must_use_correct_dialect.go
+++ b/pkg/lint/rules/must_use_correct_dialect.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type MustUseCorrectDialect struct{}

--- a/pkg/lint/rules/must_use_correct_dialect_test.go
+++ b/pkg/lint/rules/must_use_correct_dialect_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestMustUseCorrectDialect(t *testing.T) {

--- a/pkg/lint/rules/numbers_should_be_constrained.go
+++ b/pkg/lint/rules/numbers_should_be_constrained.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type NumbersShouldBeConstrained struct{}

--- a/pkg/lint/rules/numbers_should_be_constrained_test.go
+++ b/pkg/lint/rules/numbers_should_be_constrained_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestNumbersShouldBeConstrained(t *testing.T) {

--- a/pkg/lint/rules/properties_must_have_one_type.go
+++ b/pkg/lint/rules/properties_must_have_one_type.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type PropertiesMustHaveOneType struct{}

--- a/pkg/lint/rules/properties_must_have_one_type_test.go
+++ b/pkg/lint/rules/properties_must_have_one_type_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestPropertiesMustHaveOneType(t *testing.T) {

--- a/pkg/lint/rules/should_disable_additional_properties.go
+++ b/pkg/lint/rules/should_disable_additional_properties.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type ShouldDisableAdditionalProperties struct{}

--- a/pkg/lint/rules/should_disable_additional_properties_test.go
+++ b/pkg/lint/rules/should_disable_additional_properties_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestShouldDisableAdditionalProperties(t *testing.T) {

--- a/pkg/lint/rules/strings_should_be_constrained.go
+++ b/pkg/lint/rules/strings_should_be_constrained.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type StringsShouldBeConstrained struct{}

--- a/pkg/lint/rules/strings_should_be_constrained_test.go
+++ b/pkg/lint/rules/strings_should_be_constrained_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestStringsShouldBeConstrained(t *testing.T) {

--- a/pkg/lint/rules/title_correct_test.go
+++ b/pkg/lint/rules/title_correct_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestTitleCorrect(t *testing.T) {

--- a/pkg/lint/rules/title_exists.go
+++ b/pkg/lint/rules/title_exists.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type TitleExists struct{}

--- a/pkg/lint/rules/title_exists_test.go
+++ b/pkg/lint/rules/title_exists_test.go
@@ -3,7 +3,7 @@ package rules
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestTitleExists(t *testing.T) {

--- a/pkg/lint/rules/title_must_be_sentence_case.go
+++ b/pkg/lint/rules/title_must_be_sentence_case.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type TitleMustBeSentenceCase struct{}

--- a/pkg/lint/rules/title_must_not_contain_illegal_characters.go
+++ b/pkg/lint/rules/title_must_not_contain_illegal_characters.go
@@ -3,9 +3,9 @@ package rules
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type TitleMustNotContainIllegalCharacters struct{}

--- a/pkg/lint/rules/title_must_not_contain_parents_title.go
+++ b/pkg/lint/rules/title_must_not_contain_parents_title.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/utils"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type TitleShouldNotContainParentsTitle struct{}

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -3,9 +3,9 @@ package rulesets
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/lint/rules"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/rules"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type RuleSet struct {

--- a/pkg/lint/rulesets/rulesets_test.go
+++ b/pkg/lint/rulesets/rulesets_test.go
@@ -3,7 +3,7 @@ package rulesets
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestLintWithRules(t *testing.T) {

--- a/pkg/lint/utils/propertyannotations.go
+++ b/pkg/lint/utils/propertyannotations.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"fmt"
 
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type StringWithLevel struct {

--- a/pkg/lint/utils/propertyannotations_test.go
+++ b/pkg/lint/utils/propertyannotations_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint"
 )
 
 func TestBuildPropertyAnnotationsMap(t *testing.T) {

--- a/pkg/lint/utils/recurse.go
+++ b/pkg/lint/utils/recurse.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 func RecurseAll(schema *schemautils.ExtendedSchema, callback func(schema *schemautils.ExtendedSchema)) {

--- a/pkg/lint/utils/recurse_test.go
+++ b/pkg/lint/utils/recurse_test.go
@@ -3,8 +3,8 @@ package utils
 import (
 	"testing"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 type RecurseType int

--- a/pkg/schemautils/schemautils_test.go
+++ b/pkg/schemautils/schemautils_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/giantswarm/schemalint/v2/pkg/lint"
-	"github.com/giantswarm/schemalint/v2/pkg/schemautils"
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
 )
 
 func TestGetSchemasAt(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

The "Create Release PR" incorrectly changed the go module path by appending `/v2`. This PR reverts that. 

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
