### PR TITLE
Add rule to forbid empty objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add rule to check that objects are non-empty.
+
 ## [1.0.1] - 2023-03-22
 
 - Fix module path.

--- a/pkg/lint/rules/objects_must_have_properties.go
+++ b/pkg/lint/rules/objects_must_have_properties.go
@@ -1,0 +1,40 @@
+package rules
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+	"github.com/giantswarm/schemalint/pkg/lint/utils"
+	"github.com/giantswarm/schemalint/pkg/schemautils"
+)
+
+type ObjectsMustHaveProperties struct{}
+
+func (r ObjectsMustHaveProperties) Verify(schema *schemautils.ExtendedSchema) lint.RuleResults {
+	ruleResults := &lint.RuleResults{}
+
+	callback := func(schema *schemautils.ExtendedSchema) {
+		nProperties := len(schema.Properties) + len(schema.PatternProperties)
+		_, ok := schema.GetAdditionalProperties().(*schemautils.ExtendedSchema)
+		if ok {
+			nProperties++
+		}
+
+		if nProperties == 0 {
+			ruleResults.Add(
+				fmt.Sprintf(
+					"Object at %s must have at least one property.",
+					schema.GetHumanReadableLocation(),
+				),
+				schema.GetResolvedLocation(),
+			)
+		}
+	}
+
+	utils.RecurseObjects(schema, callback)
+	return *ruleResults
+}
+
+func (r ObjectsMustHaveProperties) GetSeverity() lint.Severity {
+	return lint.SeverityError
+}

--- a/pkg/lint/rules/objects_must_have_properties.go
+++ b/pkg/lint/rules/objects_must_have_properties.go
@@ -23,7 +23,7 @@ func (r ObjectsMustHaveProperties) Verify(schema *schemautils.ExtendedSchema) li
 		if nProperties == 0 {
 			ruleResults.Add(
 				fmt.Sprintf(
-					"Object at %s must have at least one property.",
+					"Object at '%s' must have at least one property.",
 					schema.GetHumanReadableLocation(),
 				),
 				schema.GetResolvedLocation(),

--- a/pkg/lint/rules/objects_must_have_properties_test.go
+++ b/pkg/lint/rules/objects_must_have_properties_test.go
@@ -1,0 +1,57 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/giantswarm/schemalint/pkg/lint"
+)
+
+func TestObjectsMustHaveProperties(t *testing.T) {
+	testCases := []struct {
+		name        string
+		schemaPath  string
+		nViolations int
+	}{
+		{
+			name:        "case 0: object without properties",
+			schemaPath:  "testdata/objects_must_have_properties/object_without_properties.json",
+			nViolations: 1,
+		},
+		{
+			name:        "case 1: object with property",
+			schemaPath:  "testdata/objects_must_have_properties/object_with_property.json",
+			nViolations: 0,
+		},
+		{
+			name:        "case 2: object with additional property",
+			schemaPath:  "testdata/objects_must_have_properties/object_with_additional_property.json",
+			nViolations: 0,
+		},
+		{
+			name:        "case 3: object with pattern property",
+			schemaPath:  "testdata/objects_must_have_properties/object_with_pattern_property.json",
+			nViolations: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema, err := lint.Compile(tc.schemaPath)
+			if err != nil {
+				t.Fatalf("Unexpected parsing error in test case '%s': %s", tc.name, err)
+			}
+
+			rule := ObjectsMustHaveProperties{}
+			ruleResults := rule.Verify(schema).Violations
+
+			if len(ruleResults) != tc.nViolations {
+				t.Fatalf(
+					"Unexpected number of rule violations in test case '%s': Expected %d, got %d",
+					tc.name,
+					tc.nViolations,
+					len(ruleResults),
+				)
+			}
+		})
+	}
+}

--- a/pkg/lint/rules/testdata/objects_must_have_properties/object_with_additional_property.json
+++ b/pkg/lint/rules/testdata/objects_must_have_properties/object_with_additional_property.json
@@ -1,0 +1,6 @@
+{
+    "additionalProperties": {
+        "type": "string"
+    },
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/objects_must_have_properties/object_with_pattern_property.json
+++ b/pkg/lint/rules/testdata/objects_must_have_properties/object_with_pattern_property.json
@@ -1,0 +1,11 @@
+{
+    "patternProperties": {
+        "^I_": {
+            "type": "integer"
+        },
+        "^S_": {
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/objects_must_have_properties/object_with_property.json
+++ b/pkg/lint/rules/testdata/objects_must_have_properties/object_with_property.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "foo": {
+            "type": "string"
+        }
+    },
+    "type": "object"
+}

--- a/pkg/lint/rules/testdata/objects_must_have_properties/object_without_properties.json
+++ b/pkg/lint/rules/testdata/objects_must_have_properties/object_without_properties.json
@@ -1,0 +1,5 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {},
+    "type": "object"
+}

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -45,6 +45,7 @@ var ClusterApp = &RuleSet{
 		rules.ArrayItemsMustHaveSingleType{},
 		rules.AvoidRecursion{},
 		rules.AvoidRecursionKeywords{},
+		rules.ObjectsMustHaveProperties{},
 	},
 	excludeLocations: []string{
 		"/properties/internal",

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -49,6 +49,7 @@ var ClusterApp = &RuleSet{
 	},
 	excludeLocations: []string{
 		"/properties/internal",
+		"/properties/cluster-shared",
 	},
 }
 
@@ -94,14 +95,20 @@ func GetRuleSet(name RuleSetName) *RuleSet {
 	return ruleSet
 }
 
-func VerifyRuleSet(name string, schema *schemautils.ExtendedSchema) (errors []string, recommendations []string) {
+func VerifyRuleSet(
+	name string,
+	schema *schemautils.ExtendedSchema,
+) (errors []string, recommendations []string) {
 	nameEnum := RuleSetName(name)
 	ruleSet := GetRuleSet(nameEnum)
 
 	return LintWithRuleSet(schema, ruleSet)
 }
 
-func LintWithRuleSet(schema *schemautils.ExtendedSchema, ruleSet *RuleSet) (errors []string, recommendations []string) {
+func LintWithRuleSet(
+	schema *schemautils.ExtendedSchema,
+	ruleSet *RuleSet,
+) (errors []string, recommendations []string) {
 	errors = []string{}
 	recommendations = []string{}
 	for _, rule := range ruleSet.rules {

--- a/pkg/lint/rulesets/rulesets_test.go
+++ b/pkg/lint/rulesets/rulesets_test.go
@@ -19,21 +19,21 @@ func TestLintWithRules(t *testing.T) {
 			schemaPath:       "testdata/cluster_azure.json",
 			ruleSetName:      "cluster-app",
 			nErrors:          0,
-			nRecommendations: 177,
+			nRecommendations: 174,
 		},
 		{
-			name:             "case 1: with ignored location",
-			schemaPath:       "testdata/with_internal.json",
+			name:             "case 1: with ignored locations",
+			schemaPath:       "testdata/with_ignored.json",
 			ruleSetName:      "cluster-app",
 			nErrors:          0,
 			nRecommendations: 0,
 		},
 		{
-			name:             "case 1: without ignored location",
-			schemaPath:       "testdata/no_internal.json",
+			name:             "case 2: without ignored locations",
+			schemaPath:       "testdata/no_ignored.json",
 			ruleSetName:      "cluster-app",
-			nErrors:          1,
-			nRecommendations: 6,
+			nErrors:          3,
+			nRecommendations: 9,
 		},
 	}
 

--- a/pkg/lint/rulesets/testdata/no_ignored.json
+++ b/pkg/lint/rulesets/testdata/no_ignored.json
@@ -11,6 +11,9 @@
             },
             "title": "Internal settings",
             "type": "object"
+        },
+        "no-cluster-shared": {
+            "type": "object"
         }
     },
     "title": "Cluster configuration",

--- a/pkg/lint/rulesets/testdata/with_ignored.json
+++ b/pkg/lint/rulesets/testdata/with_ignored.json
@@ -11,6 +11,9 @@
             },
             "title": "Internal settings",
             "type": "object"
+        },
+        "cluster-shared": {
+            "type": "object"
         }
     },
     "title": "Cluster configuration",

--- a/pkg/schemautils/schemautils.go
+++ b/pkg/schemautils/schemautils.go
@@ -44,6 +44,20 @@ func (schema *ExtendedSchema) GetProperties() []*ExtendedSchema {
 	return properties
 }
 
+// GetAdditionalProperties returns nil or bool or *ExtendedSchema
+func (schema *ExtendedSchema) GetAdditionalProperties() interface{} {
+	if schema.AdditionalProperties == nil {
+		return nil
+	}
+	if schema.AdditionalProperties == true {
+		return true
+	}
+	if schema.AdditionalProperties == false {
+		return false
+	}
+	return NewExtendedSchema(schema.AdditionalProperties.(*jsonschema.Schema))
+}
+
 func (schema *ExtendedSchema) InheritParentFrom(other *ExtendedSchema) {
 	schema.Parent = other.Parent
 	schema.ParentPath = other.ParentPath


### PR DESCRIPTION
### What does this PR do?

This PR adds a new rule to check that objects have at least one property specified through one of `properties`, `additionalProperties` and `patternProperties`.

This PR also adds `.cluster-shared` to the list of excluded locations.

### What is the effect of this change to users?

Users that run the `verify` command with the `--rule-set` cluster-app flag will see additional errors.

### How does it look like?

```
Errors (1)

- Object at / must have at least one property.
```

### Any background context you can provide?

Towards https://github.com/giantswarm/roadmap/issues/1772
Closes https://github.com/giantswarm/roadmap/issues/2110

### What is needed from the reviewers?

You can test the changes with:
```
go run main.go verify --rule-set cluster-app ./pkg/lint/rules/testdata/objects_must_have_properties/object_without_properties.json
```

### Do the docs/README need to be updated?

No

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
