### PR TITLE
Allow root-level object `global` for sharing values with subcharts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Allow root-level object `global` for sharing values with subcharts
+
 ## [2.1.1] - 2023-04-25
 
 ## [2.1.0] - 2023-04-25
@@ -21,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.0] - 2023-04-18
 
-- Adapt common schema structure to cluster-aws. 
+- Adapt common schema structure to cluster-aws.
 - Only recommend examples on restricted strings.
 - Add the possibility to include a URL for further reference to rule sets, which is displayed in the output.
 - Hint to developer how to normalize the JSON schema file.

--- a/pkg/lint/rules/adheres_to_common_schema_structure_requirements.go
+++ b/pkg/lint/rules/adheres_to_common_schema_structure_requirements.go
@@ -62,6 +62,7 @@ func getAddtionalAllowedRootPropertiesNames() []string {
 		"provider",
 		"cluster-shared",
 		"kubectlImage",
+		"global", // values shared with subcharts
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/giantswarm/issues/28310#issuecomment-1802094447

`cluster-*` charts may depend on the common `cluster` chart in the future, so allow using `.Values.global.*` to share values with the subchart.

### How does it look like?

Prevents this error:

```
Root-level property is not allowed
  - /global
```

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
