### PR TITLE
Add support for root-level properties being moved to be under global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support for refactored schema where root-level properties are moved to be under global property.
+
 ## [2.2.1] - 2023-11-09
 
 ## [2.2.0] - 2023-11-09

--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -10,7 +10,7 @@ runs:
       uses: giantswarm/install-binary-action@v1.1.0
       with:
         binary: "schemalint"
-        version: "2.2.1"
+        version: "2.3.0-alpha.0"
     - name: Run schemalint
       shell: bash
       run: ${{ github.action_path }}/verify-helm-schema.sh ${{ inputs.rule-set }}

--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -10,7 +10,7 @@ runs:
       uses: giantswarm/install-binary-action@v1.1.0
       with:
         binary: "schemalint"
-        version: "2.3.0-alpha.0"
+        version: "2.2.1"
     - name: Run schemalint
       shell: bash
       run: ${{ github.action_path }}/verify-helm-schema.sh ${{ inputs.rule-set }}

--- a/pkg/lint/rules/adheres_to_common_schema_structure_requirements_test.go
+++ b/pkg/lint/rules/adheres_to_common_schema_structure_requirements_test.go
@@ -57,6 +57,21 @@ func TestAdheheresToCommonSchemaStructureRequirements(t *testing.T) {
 			schemaPath:  "testdata/common_schema_structure_requirements/additional_properties_not_set_to_false.json",
 			nViolations: 1,
 		},
+		{
+			name:        "case 9: correct global properties",
+			schemaPath:  "testdata/common_schema_structure_requirements/correct_global.json",
+			nViolations: 0,
+		},
+		{
+			name:        "case 10: correct global and root-level properties mix (allowed during schema refactoring, will be removed in the future)",
+			schemaPath:  "testdata/common_schema_structure_requirements/correct_global_root_mix.json",
+			nViolations: 0,
+		},
+		{
+			name:        "case 11: incorrect global and root-level properties mix",
+			schemaPath:  "testdata/common_schema_structure_requirements/incorrect_global_root_mix.json",
+			nViolations: 1,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/additional_properties_not_set_to_false.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/additional_properties_not_set_to_false.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "properties": {

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/correct.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/correct.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/correct_global.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/correct_global.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/correct_global.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/correct_global.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "global": {
+            "type": "object",
+            "properties": {
+                "connectivity": {
+                    "type": "object"
+                },
+                "controlPlane": {
+                    "type": "object"
+                },
+                "metadata": {
+                    "type": "object"
+                },
+                "nodePools": {
+                    "type": "array"
+                }
+            }
+        }
+    }
+}

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/correct_global_root_mix.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/correct_global_root_mix.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/correct_global_root_mix.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/correct_global_root_mix.json
@@ -1,0 +1,25 @@
+{
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "controlPlane": {
+            "type": "object"
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "connectivity": {
+                    "type": "object"
+                },
+                "metadata": {
+                    "type": "object"
+                }
+            }
+        },
+        "nodePools": {
+            "type": "array"
+        }
+    }
+}

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/correct_with_optional_fields.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/correct_with_optional_fields.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/incorrect_global_root_mix.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/incorrect_global_root_mix.json
@@ -1,0 +1,28 @@
+{
+    "$id": "https://example.com/person.schema.json",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "controlPlane": {
+            "type": "object"
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "connectivity": {
+                    "type": "object"
+                },
+                "metadata": {
+                    "type": "object"
+                }
+            }
+        },
+        "metadata": {
+            "type": "object"
+        },
+        "nodePools": {
+            "type": "array"
+        }
+    }
+}

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/incorrect_global_root_mix.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/incorrect_global_root_mix.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/missing_all.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/missing_all.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/missing_connectivity.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/missing_connectivity.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/missing_control_plane.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/missing_control_plane.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/missing_metadata.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/missing_metadata.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/missing_node_pools.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/missing_node_pools.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/too_many.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/too_many.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,

--- a/pkg/lint/rules/testdata/common_schema_structure_requirements/wrong_types.json
+++ b/pkg/lint/rules/testdata/common_schema_structure_requirements/wrong_types.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://example.com/person.schema.json",
+    "$id": "https://example.com/cluster.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "type": "object",
     "additionalProperties": false,


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/roadmap/issues/2954

We have ported all provider-independent Cluster API resources to cluster chart, which was phase 1 of restructuring of cluster- apps, see https://github.com/giantswarm/roadmap/issues/2742 for more details. Now we want to use cluster chart in cluster-aws and remove all provider-independent Cluster API resources from cluster-aws.

In order to do so, first we have to refactor cluster-aws Helm values, so that cluster chart can read provider-independent values it needs. For that, we have to move current top-level properties to be under Values.global.

This pull request adds schema support for old required root-level properties to be under `Values.global` property.

Since the refactoring of all cluster apps for all providers will take some time, with this change the validation allows that old root-level properties must be either root-level or under global (both are not allowed).

When the refactoring of all cluster apps is completed, we will remove the validation of old root-level properties and allow that they are only under global.

### What is the effect of this change to users?

KaaS developers can refactor cluster apps by moving top-level required properties to be under global property, and the schema will be valid after the refactoring is done (and also during the refactoring if properties are moved one by one).

### How does it look like?

The following JSON schemas are now correct.

Correct global properties:

```JSON
{
    "$id": "https://example.com/person.schema.json",
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "type": "object",
    "additionalProperties": false,
    "properties": {
        "global": {
            "type": "object",
            "properties": {
                "connectivity": {
                    "type": "object"
                },
                "controlPlane": {
                    "type": "object"
                },
                "metadata": {
                    "type": "object"
                },
                "nodePools": {
                    "type": "array"
                }
            }
        }
    }
}
```

Correct global and root-level properties mix (allowed during schema refactoring, will be removed in the future):

```
{
    "$id": "https://example.com/person.schema.json",
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "type": "object",
    "additionalProperties": false,
    "properties": {
        "controlPlane": {
            "type": "object"
        },
        "global": {
            "type": "object",
            "properties": {
                "connectivity": {
                    "type": "object"
                },
                "metadata": {
                    "type": "object"
                }
            }
        },
        "nodePools": {
            "type": "array"
        }
    }
}
```

Incorrect global and root-level properties mix, as `metadata` is both root-level and global property:

```
{
    "$id": "https://example.com/person.schema.json",
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "type": "object",
    "additionalProperties": false,
    "properties": {
        "controlPlane": {
            "type": "object"
        },
        "global": {
            "type": "object",
            "properties": {
                "connectivity": {
                    "type": "object"
                },
                "metadata": {
                    "type": "object"
                }
            }
        },
        "metadata": {
            "type": "object"
        },
        "nodePools": {
            "type": "array"
        }
    }
}
```

### Any background context you can provide?

- https://github.com/giantswarm/roadmap/issues/2739
- https://github.com/giantswarm/roadmap/issues/2954

### What is needed from the reviewers?

Feedback and suggestions.

### Do the docs/README need to be updated?

No.

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
