### PR TITLE
Don't check global.apps in cluster-app ruleset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Don't check `global.apps` in cluster-app ruleset, so we can have empty objects without defined properties (until we auto-generate full schemas from actual app schemas). 
+
 ## [2.3.1] - 2023-11-23
 
 - Allow to have the same field as a both global and root-level property. 

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -50,6 +50,7 @@ var ClusterApp = &RuleSet{
 		rules.ObjectsMustHaveProperties{},
 	},
 	excludeLocations: []string{
+		"/properties/global/properties/apps",
 		"/properties/internal",
 		"/properties/cluster-shared",
 	},

--- a/pkg/lint/rulesets/rulesets_test.go
+++ b/pkg/lint/rulesets/rulesets_test.go
@@ -1,6 +1,8 @@
 package rulesets
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/giantswarm/schemalint/v2/pkg/schema"
@@ -26,7 +28,7 @@ func TestLintWithRules(t *testing.T) {
 			schemaPath:       "testdata/with_ignored.json",
 			ruleSetName:      "cluster-app",
 			nErrors:          4,
-			nRecommendations: 1,
+			nRecommendations: 2,
 		},
 		{
 			name:             "case 2: without ignored locations",
@@ -53,19 +55,37 @@ func TestLintWithRules(t *testing.T) {
 
 			errors, recommendations := Verify(tc.ruleSetName, s)
 			if len(errors.Violations) != tc.nErrors {
+				var errorMessages []string
+				for i, violation := range errors.Violations {
+					errorMessages = append(
+						errorMessages,
+						fmt.Sprintf("%d. %s: %s", i+1, violation.Location, violation.Message))
+				}
+				mergedMessages := strings.Join(errorMessages, "\n")
+
 				t.Fatalf(
-					"Unexpected number of errors in test case '%s': Expected %d, got %d",
+					"Unexpected number of errors in test case '%s': Expected %d, got %d\n\nErrors:\n%s",
 					tc.name,
 					tc.nErrors,
 					len(errors.Violations),
+					mergedMessages,
 				)
 			}
 			if len(recommendations.Violations) != tc.nRecommendations {
+				var recommendationMessages []string
+				for i, recommendation := range recommendations.Violations {
+					recommendationMessages = append(
+						recommendationMessages,
+						fmt.Sprintf("%d. %s: %s", i+1, recommendation.Location, recommendation.Message))
+				}
+				mergedMessages := strings.Join(recommendationMessages, "\n")
+
 				t.Fatalf(
-					"Unexpected number of recommendations in test case '%s': Expected %d, got %d",
+					"Unexpected number of recommendations in test case '%s': Expected %d, got %d\n\nRecommendations:\n%s",
 					tc.name,
 					tc.nRecommendations,
 					len(recommendations.Violations),
+					mergedMessages,
 				)
 			}
 		})

--- a/pkg/lint/rulesets/testdata/with_ignored.json
+++ b/pkg/lint/rulesets/testdata/with_ignored.json
@@ -8,6 +8,23 @@
         "cluster-shared": {
             "type": "object"
         },
+        "global": {
+            "type": "object",
+            "title": "Global",
+            "description": "Properties that are shared across all parent and subcharts.",
+            "properties": {
+                "apps": {
+                    "type": "object",
+                    "title": "Apps",
+                    "properties": {
+                        "cilium": {
+                            "type": "object",
+                            "title": "Cilium"
+                        }
+                    }
+                }
+            }
+        },
         "internal": {
             "title": "Internal settings",
             "type": "object",


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/cluster-aws/pull/432.

This PR excludes `Values.global.apps` from `cluster-app` ruleset. Properties under `Values.global.apps.*` will be optional overrides of apps' Helm values.

Ideally we woul auto-generate full schemas for optional app configs in `Values.global.apps.*`, which we want to do in the future since it requires a non-trivial work, as a simple usage of app schemas (e.g. see cilium app schema [here](https://github.com/giantswarm/cilium-app/blob/main/helm/cilium/values.schema.json)) doesn't do the job, since schema for optional app Helm values overrides (e.g. overriding cilium config for some cluster) would be slightly different from the original app schema, e.g. it would be less strict.

Therefore, for now we go with a free-form object for `Values.global.apps.*` in `cluster-$provider` apps, and let the app itself to perform the validation once the values are set there.

### What is the effect of this change to users?

This unblocks https://github.com/giantswarm/cluster-aws/pull/432, which is needed in order to enable customers to set custom Helm values for apps deployed with HelmReleases inside of `cluster-$provider` app. e.g. customers will be able to override Helm values for cilium, coreDNS, aws-ebs-csi-driver, etc.

### How does it look like?

Having something like this in cluster-$provider app schema, where `.global.apps.cilium` is an object without any defined property (so a free-form object), is now possible:

```JSON
{
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "title": "Cluster configuration",
    "description": "Configuration of an Azure cluster using Cluster API",
    "type": "object",
    "additionalProperties": false,
    "properties": {
        "global": {
            "type": "object",
            "title": "Global",
            "description": "Properties that are shared across all parent and subcharts.",
            "properties": {
                "apps": {
                    "type": "object",
                    "title": "Apps",
                    "properties": {
                        "cilium": {
                            "type": "object",
                            "title": "Cilium"
                        }
                    }
                }
            }
        }
    }
}
```

### Any background context you can provide?

- https://github.com/giantswarm/roadmap/issues/2940
- https://github.com/giantswarm/cluster-aws/pull/432

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
