### PR TITLE
Don't check cluster and providerIntegration properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /schemalint
+/schemalint-v*-*-*-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Don't check `cluster` in cluster-app ruleset, because that property should never be modified, and it is used for configuring cluster chart.
+- Don't check `providerIntegration` in cluster-app ruleset, because here we have static properties that are set only in the provider-specific charts.
+
 ## [2.4.0] - 2023-11-24
 
 - Don't check `global.apps` in cluster-app ruleset, so we can have empty objects without defined properties (until we auto-generate full schemas from actual app schemas). 

--- a/pkg/lint/rulesets/rulesets.go
+++ b/pkg/lint/rulesets/rulesets.go
@@ -52,6 +52,8 @@ var ClusterApp = &RuleSet{
 	excludeLocations: []string{
 		"/properties/global/properties/apps",
 		"/properties/internal",
+		"/properties/providerIntegration",
+		"/properties/cluster",
 		"/properties/cluster-shared",
 	},
 	referenceURL: "https://github.com/giantswarm/rfc/pull/55", // should be updated when PR is merged


### PR DESCRIPTION
### What does this PR do?

Towards https://github.com/giantswarm/roadmap/issues/3047

- Don't check `cluster` in cluster-app ruleset, because that property should never be modified, and it is used for configuring cluster chart.
- Don't check `providerIntegration` in cluster-app ruleset, because here we have static properties that are set only in the provider-specific charts.

### What is the effect of this change to users?

KaaS developers can work on integration of `cluster` chart into `cluster-<provider>` charts.

### How does it look like?

`cluster-<provider>` chart can specify values like this:

```YAML
cluster:
  providerIntegration:
    resourcesApi:
      infrastructureCluster:
        group: infrastructure.cluster.x-k8s.io
        version: v1beta2
        kind: AWSCluster
```

### Any background context you can provide?

https://github.com/giantswarm/roadmap/issues/3047

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
