### PR TITLE
Update schemalint version in GitHub action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Update schemalint version in the GitHub action.
+
 ## [2.5.0] - 2023-12-15
 
 - Don't check `cluster` in cluster-app ruleset, because that property should never be modified, and it is used for configuring cluster chart.

--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -10,7 +10,7 @@ runs:
       uses: giantswarm/install-binary-action@v1.1.0
       with:
         binary: "schemalint"
-        version: "2.4.0"
+        version: "2.5.0"
     - name: Run schemalint
       shell: bash
       run: ${{ github.action_path }}/verify-helm-schema.sh ${{ inputs.rule-set }}


### PR DESCRIPTION
### What does this PR do?

For some reason, when releasing v2.5.0 [here](https://github.com/giantswarm/schemalint/pull/138/files) the schemalint version in the GitHub action did not get updated.

This PR is updating schemalint version in the GitHub action to released v2.5.0.

### What is the effect of this change to users?

cluster app PRs are using the latest schemalint version.

### Any background context you can provide?

We need these to work in cluster app PRs:
- https://github.com/giantswarm/schemalint/pull/138
- https://github.com/giantswarm/schemalint/pull/137

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
