### PR TITLE
Add pre-commit hooks for `normalize` and `verify` commands

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+
+- id: schemalint-normalize
+  name: schemalint-normalize
+  description: Normalize JSON schema files
+  entry: schemalint normalize
+  language: golang
+  files: \.json$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,4 @@
   entry: schemalint normalize
   language: golang
   files: \.json$
+  require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
   description: Normalize JSON schema files
   entry: schemalint normalize
   language: golang
-  files: \.json$
+  files: \.schema\.json$ # Adapt this in your .pre-commit-config.yaml to match your schema file names
   require_serial: true
 
 # verify
@@ -13,4 +13,4 @@
   description: Verify JSON schema files
   entry: schemalint verify
   language: golang
-  files: \.json$
+  files: \.schema\.json$ # Adapt this in your .pre-commit-config.yaml to match your schema file names

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,4 +1,4 @@
-
+# normalize
 - id: schemalint-normalize
   name: normalize JSON Schema
   description: Normalize JSON schema files
@@ -6,3 +6,11 @@
   language: golang
   files: \.json$
   require_serial: true
+
+# verify
+- id: schemalint-verify
+  name: verify JSON Schema
+  description: Verify JSON schema files
+  entry: schemalint verify
+  language: golang
+  files: \.json$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 
 - id: schemalint-normalize
-  name: schemalint-normalize
+  name: normalize JSON Schema
   description: Normalize JSON schema files
   entry: schemalint normalize
   language: golang

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add [pre-commit](https://pre-commit.com/) hooks
+
 ## [2.5.1] - 2023-12-19
 
 - Update schemalint version in the GitHub action.
@@ -18,11 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.4.0] - 2023-11-24
 
-- Don't check `global.apps` in cluster-app ruleset, so we can have empty objects without defined properties (until we auto-generate full schemas from actual app schemas). 
+- Don't check `global.apps` in cluster-app ruleset, so we can have empty objects without defined properties (until we auto-generate full schemas from actual app schemas).
 
 ## [2.3.1] - 2023-11-23
 
-- Allow to have the same field as a both global and root-level property. 
+- Allow to have the same field as a both global and root-level property.
 
 ## [2.3.0] - 2023-11-16
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Verification result
 To validate a **cluster app** schema, apply the `--rule-set cluster-app` option.
 
 ```nohighlight
-$ schemalint verify myschema.json --rule-set cluster-app
+schemalint verify myschema.json --rule-set cluster-app
 ```
 
 **Note:** Cluster app schema validation is experimental and in development. The requirements are in discussion in [this RFC draft](https://github.com/giantswarm/rfc/pull/55).
@@ -50,11 +50,10 @@ Use `--help` to learn about more options.
 Create a normalized (white space, sorting) representation of a JSON Schema file. This helps to avoid purely cosmetical changes to a schema.
 
 ```nohighlight
-$ schemalint normalize myschema.json > normalized.json
+schemalint normalize myschema.json > normalized.json
 ```
 
 Use `--help` to learn about more options.
-
 
 ## GitHub Action
 
@@ -82,11 +81,17 @@ jobs:
 ```
 
 Note that it is possible to define the rule set to be used for the `verify` command with the `with` keyword.
+
 ```yaml
 with:
   rule-set: 'RULE_SET'
 ```
+
 If the rule set is not specified, no rule set will be used.
+
+## Pre-commit Hook
+
+This repository provides a [pre-commit hook](https://pre-commit.com/#new-hooks) that can be used to normalize JSON schema files before committing them. See `.pre-commit-hooks.yaml` for more information.
 
 ## Major Releases
 
@@ -95,12 +100,13 @@ Other repositories that use schemalint point to major floating tag versions,
 like `v1`. That means that all minor and patch releases will be automatically
 rolled out to these repositories.
 
-When doing a major release the references to schemalint have to be manually 
+When doing a major release the references to schemalint have to be manually
 updated.
-- devctl: 
+
+- devctl:
   - `pkg/gen/input/workflows/internal/file/cluster_app_schema_validation.yaml.template`
   - `pkg/gen/input/makefile/internal/file/Makefile.gen.cluster_app.mk.template`
-- schema: 
+- schema:
   - `.github/workflows/lint.yaml
 
 ## "Overriding" Properties and Understanding `PropertyAnnotationsMap`
@@ -145,6 +151,7 @@ Here, the property at the location `.rootProp.childProp` has two different
 definitions.
 
 One is in the original schema:
+
 ```json
 {
   "type": "string",
@@ -152,7 +159,9 @@ One is in the original schema:
   "title": "This title will be used"
 }
 ```
+
 And the other one is in the referenced schema:
+
 ```json
 {
   "type": "string",
@@ -164,7 +173,7 @@ And the other one is in the referenced schema:
 In JSON schema specification is no such thing as overriding or merging. The
 keywords that have actual meaning during validation will be applied
 sequentially (e.g. `minLength`, `maxLength` and `type`).
-In our example a payload that conforms to the given schema would need to have 
+In our example a payload that conforms to the given schema would need to have
 a string of length 2,3 or 4 at the location `.rootProp.childProp`.
 
 The JSON schema specification does not specify how to handle multiple

--- a/pkg/normalize/normalize.go
+++ b/pkg/normalize/normalize.go
@@ -1,4 +1,4 @@
-// Package normalize providesa a function to process a JSON input and return it in
+// Package normalize provides a a function to process a JSON input and return it in
 // normalized form.
 package normalize
 


### PR DESCRIPTION
### What does this PR do?

This PR adds configuration so that the `schemalint normalize` and `schemalint verify` commands can be used as [pre-commit](https://pre-commit.com/) hooks.

### What is the effect of this change to users?

Schema linting and normalization can be part of the developer-side automation that can help speed of dev rouund-trips.

### How does it look like?

The application can be seen in https://github.com/giantswarm/hello-world-app/blob/helm-schema-annotations/.pre-commit-config.yaml

### Do the docs/README need to be updated?

Done

### Should this change be mentioned in the release notes?

- [x] CHANGELOG.md has been updated
