### PR TITLE
fix(action): Provide download URL.

### DIFF
--- a/actions/verify-helm-schema/action.yml
+++ b/actions/verify-helm-schema/action.yml
@@ -9,8 +9,9 @@ runs:
     - name: Install schemalint
       uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
       with:
-        binary: "schemalint"
-        version: "2.6.2"
+        binary: schemalint
+        version: 2.6.2
+        download_url: https://github.com/giantswarm/${binary}/releases/download/v${version}/${binary}-linux-amd64
     - name: Run schemalint
       shell: bash
       run: ${{ github.action_path }}/verify-helm-schema.sh ${{ inputs.rule-set }}


### PR DESCRIPTION
We no longer upload the binary as a tarball, so the download URL to the plain binary has to be provided here.