### PR TITLE
feat(ci): self-test the verify-helm-schema action

### DIFF
--- a/.github/workflows/verify_action.yaml
+++ b/.github/workflows/verify_action.yaml
@@ -1,0 +1,69 @@
+# Runs `actions/verify-helm-schema` against a fixture chart, so this repo notices when its own
+# action stops working.
+#
+# Why it exists: v2.6.2 shipped a correct-looking action.yml next to a release whose assets had
+# been renamed out from under it. The `chore: align files according to platform standards` template
+# dropped `build-release-artifacts: true` from `zz_generated.create_release.yaml` (#319), so
+# `schemalint-v2.6.2-linux-amd64.tar.gz` was never built - while action.yml was still asking
+# install-binary-action for exactly that file. Every consumer of
+# giantswarm/github-workflows/.github/workflows/json-schema-validation.yaml@main started failing
+# with `Unexpected HTTP response: 404` within a minute of Renovate bumping the pin there, and
+# nothing in this repo noticed, because no workflow here ran its own action.
+#
+# The action is referenced by **local path**, so whatever action.yml currently pins is what gets
+# tested - there is no second copy of the version or URL to drift out of sync.
+#
+# `release: published` is the trigger that matters: release assets are final at that moment, which
+# is before Renovate can propagate the new version downstream. The daily schedule is a safety net
+# for assets that are renamed or deleted after the fact. There is deliberately no `pull_request`
+# trigger - `update_action.yaml` bumps the pinned version on the release PR branch *before* that
+# release exists, so a PR-time install would 404 on every release PR.
+
+name: Verify action
+
+on:
+  # TEMPORARY, removed before merge: workflow_dispatch only works from the default branch, so this
+  # is the only way to prove the job actually runs while it is still on a PR branch.
+  pull_request:
+    paths:
+      - '.github/workflows/verify_action.yaml'
+  release:
+    types: [published]
+  schedule:
+    - cron: '17 6 * * *'
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  verify-helm-schema:
+    name: Install and run the verify-helm-schema action
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+
+      # `verify-helm-schema.sh` locates its input with `find ./helm -maxdepth 2 -name
+      # values.schema.json`, so the fixture has to live there. Normalizing with the checked-out
+      # source instead of committing a fixture means it satisfies `verify`'s normalization gate for
+      # free and cannot go stale; `rulesets_test.go` already asserts this input has no `cluster-app`
+      # errors (its ~90 recommendations are advisory and do not fail the run).
+      - name: Build the fixture chart
+        run: |
+          mkdir -p helm/selftest
+          go run . normalize pkg/lint/rulesets/testdata/cluster_azure.json \
+            -o helm/selftest/values.schema.json --force
+
+      - name: Run the action
+        uses: ./actions/verify-helm-schema
+        with:
+          rule-set: cluster-app

--- a/.github/workflows/verify_action.yaml
+++ b/.github/workflows/verify_action.yaml
@@ -22,11 +22,6 @@
 name: Verify action
 
 on:
-  # TEMPORARY, removed before merge: workflow_dispatch only works from the default branch, so this
-  # is the only way to prove the job actually runs while it is still on a PR branch.
-  pull_request:
-    paths:
-      - '.github/workflows/verify_action.yaml'
   release:
     types: [published]
   schedule:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- CI: `verify_action.yaml` runs `actions/verify-helm-schema` against a fixture chart on every
+  published release (plus daily), so a release whose assets no longer match what `action.yml`
+  downloads is caught here instead of in every repo consuming
+  `giantswarm/github-workflows/.github/workflows/json-schema-validation.yaml@main`. This is what
+  v2.6.2 needed: its assets stopped including `schemalint-v2.6.2-linux-amd64.tar.gz` once #319
+  dropped `build-release-artifacts: true`, and the resulting 404 only surfaced downstream.
+
 ## [2.6.3] - 2026-08-04
 
 ### Changed


### PR DESCRIPTION
Part of [giantswarm/giantswarm#37347](https://github.com/giantswarm/giantswarm/issues/37347) — *Lack of schema testing in github-workflows lets bugs pass*

Closes the gap that made v2.6.2 an org-wide outage.

## What happened

v2.6.2 shipped a perfectly correct `action.yml` next to a release that no longer had the asset it downloads.

`chore: align files according to platform standards` (#319) removed `build-release-artifacts: true` from `zz_generated.create_release.yaml`. That input is what makes `giantswarm/github-workflows`' `create_and_upload_build_artifacts` job build the legacy `schemalint-v<version>-<platform>.tar.gz` assets — so from v2.6.2 on, they simply were not built. Meanwhile `action.yml` was still asking `install-binary-action` for exactly that filename via its default `download_url`.

Result: every repo consuming `giantswarm/github-workflows/.github/workflows/json-schema-validation.yaml@main` started failing with `Unexpected HTTP response: 404` within a minute of Renovate bumping the pin there. Example: [cluster-aks run 30920183465](https://github.com/giantswarm/cluster-aks/actions/runs/30920183465/job/92030106426).

v2.6.3 already fixed it by setting an explicit `download_url` pointing at the raw `schemalint-linux-amd64` binary. **This PR adds the check that would have caught it here first.** Nothing in this repo has ever run its own action, so the only test coverage was other people's CI.

## Design notes

- **Local path reference** (`uses: ./actions/verify-helm-schema`) — whatever `action.yml` currently pins is what gets tested. No second copy of the version or URL to drift out of sync.
- **`release: published` is the trigger that matters.** Release assets are final at that moment, which is *before* Renovate can propagate the version downstream. A daily schedule backs it up for assets renamed or deleted after the fact.
- **No `pull_request` trigger on `actions/**`.** `update_action.yaml` bumps the pinned version on the release PR branch *before* that release exists, so a PR-time install would 404 on every single release PR.
- **The fixture is generated, not committed.** `verify-helm-schema.sh` globs `./helm -maxdepth 2 -name values.schema.json`, so it has to live there. Normalizing `pkg/lint/rulesets/testdata/cluster_azure.json` with the checked-out source satisfies `verify`'s normalization gate for free and cannot go stale — and `rulesets_test.go` already asserts that input has no `cluster-app` errors.

## Verification

`workflow_dispatch` only works from the default branch, so this PR carries a **temporary** `pull_request` trigger purely to prove the job runs. It is removed in a follow-up commit on this branch before merge.

Locally, the fixture step and the gate both pass:

```
$ go run . normalize pkg/lint/rulesets/testdata/cluster_azure.json -o helm/selftest/values.schema.json --force
Normalized output written to helm/selftest/values.schema.json.
$ go run . verify helm/selftest/values.schema.json --rule-set cluster-app; echo "EXIT=$?"
[SUCCESS] Input is valid JSON Schema.
[SUCCESS] Input is normalized.
[SUCCESS] Input is valid according to rule set 'cluster-app'.
EXIT=0
```

## Related

- `giantswarm/github-workflows#262` — the mirror-image guard: a self-test so a bad action pin cannot merge there and go live org-wide. Its negative test reproduced this exact 404.
- `giantswarm/github-workflows#263` — the same latent bug found in `gitsemver`, which lost `build-release-artifacts: true` in giantswarm/gitsemver#260 and has not released since.
- The durable fix belongs in the align-files template, which silently stops tarball production without updating the consumers that request tarballs by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

